### PR TITLE
feat(auth): add forgot/reset password flow, tokens, DTOs, and endpoints

### DIFF
--- a/src/auth/interfaces/email.interface.ts
+++ b/src/auth/interfaces/email.interface.ts
@@ -1,5 +1,7 @@
 export interface EmailService {
   sendVerificationEmail(to: string, token: string, firstName: string): Promise<void>;
+  sendPasswordResetEmail?(to: string, token: string, firstName: string): Promise<void>;
+  sendPasswordChangedEmail?(to: string, firstName: string): Promise<void>;
 }
 
 export interface VerificationEmailData {

--- a/src/users/dtos/forgot-password.dto.ts
+++ b/src/users/dtos/forgot-password.dto.ts
@@ -1,0 +1,7 @@
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+}

--- a/src/users/dtos/reset-password.dto.ts
+++ b/src/users/dtos/reset-password.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsString, MinLength, Matches } from 'class-validator';
+
+export class ResetPasswordDto {
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(8)
+  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]+$/)
+  newPassword: string;
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -44,6 +44,15 @@ export class User {
     emailVerificationTokenExpiry: Date | null;
 
     @Column({ nullable: true })
+    resetPasswordTokenSelector: string | null;
+
+    @Column({ nullable: true })
+    resetPasswordTokenHash: string | null;
+
+    @Column({ nullable: true, type: 'timestamp' })
+    resetPasswordTokenExpiry: Date | null;
+
+    @Column({ nullable: true })
     refreshTokenHash: string | null;
 
     @CreateDateColumn()

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -2,6 +2,9 @@ import { Controller, Post, Body, UseGuards, Request, HttpCode, HttpStatus } from
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from '../auth/auth.service';
 import { ChangePasswordDto } from './dtos/change-password.dto';
+import { ForgotPasswordDto } from './dtos/forgot-password.dto';
+import { ResetPasswordDto } from './dtos/reset-password.dto';
+import { Public } from '../auth/decorators/public.decorator';
 
 @Controller('users')
 export class UsersController {
@@ -13,5 +16,19 @@ export class UsersController {
   async changePassword(@Request() req, @Body() changePasswordDto: ChangePasswordDto) {
     const user = req.user;
     return this.authService.changePassword(user.id, changePasswordDto);
+  }
+
+  @Public()
+  @Post('forgot-password')
+  @HttpCode(HttpStatus.OK)
+  async forgotPassword(@Body() forgotDto: ForgotPasswordDto) {
+    return this.authService.forgotPassword(forgotDto.email);
+  }
+
+  @Public()
+  @Post('reset-password')
+  @HttpCode(HttpStatus.OK)
+  async resetPassword(@Body() resetDto: ResetPasswordDto) {
+    return this.authService.resetPassword(resetDto.token, resetDto.newPassword);
   }
 }


### PR DESCRIPTION
Closes #30
# Implement Forgot Password Flow

## Description
This PR introduces password reset functionality via email, allowing users to securely reset their credentials. The flow ensures tokens are time-bound, one-time use, and handled in a way that preserves security even for non-existent accounts.

## Tasks
- Create `POST /users/forgot-password` endpoint  
- Generate secure reset token  
- Store token with expiry in database  
- Send password reset email  
- Create `POST /users/reset-password` endpoint  
- Validate token and update password  
- Invalidate token after use  

## Acceptance Criteria
- [x] Reset email is sent to registered email addresses  
- [x] Tokens expire after 1 hour  
- [x] Tokens are one-time use only  
- [x] Endpoint returns success even for non-existent emails (security best practice)  

## Labels
- auth  
- backend  
- security  
- user-management