### PR TITLE
feat(kyc): add KYC status management, endpoints, and email notifications

### DIFF
--- a/src/auth/interfaces/email.interface.ts
+++ b/src/auth/interfaces/email.interface.ts
@@ -2,6 +2,8 @@ export interface EmailService {
   sendVerificationEmail(to: string, token: string, firstName: string): Promise<void>;
   sendPasswordResetEmail?(to: string, token: string, firstName: string): Promise<void>;
   sendPasswordChangedEmail?(to: string, firstName: string): Promise<void>;
+  sendKYCSubmittedEmail?(to: string, firstName: string): Promise<void>;
+  sendKYCStatusChangeEmail?(to: string, firstName: string, status: string, rejectionReason?: string): Promise<void>;
 }
 
 export interface VerificationEmailData {

--- a/src/users/dtos/submit-kyc.dto.ts
+++ b/src/users/dtos/submit-kyc.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class SubmitKYCDto {
+  @IsString()
+  @IsNotEmpty()
+  documentUrl: string;
+}

--- a/src/users/dtos/update-kyc.dto.ts
+++ b/src/users/dtos/update-kyc.dto.ts
@@ -1,0 +1,12 @@
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { KYCStatus } from '../entities/user.entity';
+
+export class UpdateKYCDto {
+  @IsEnum(KYCStatus)
+  @IsNotEmpty()
+  status: KYCStatus;
+
+  @IsString()
+  @IsOptional()
+  rejectionReason?: string;
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -7,6 +7,13 @@ export enum UserRole {
     DONOR = 'donor',
 }
 
+export enum KYCStatus {
+    NONE = 'none',
+    PENDING = 'pending',
+    APPROVED = 'approved',
+    REJECTED = 'rejected',
+}
+
 @Entity('users')
 export class User {
     @PrimaryGeneratedColumn('uuid')
@@ -54,6 +61,25 @@ export class User {
 
     @Column({ nullable: true })
     refreshTokenHash: string | null;
+
+    @Column({
+        type: 'enum',
+        enum: KYCStatus,
+        default: KYCStatus.NONE,
+    })
+    kycStatus: KYCStatus;
+
+    @Column({ nullable: true, type: 'timestamp' })
+    kycSubmittedAt: Date | null;
+
+    @Column({ nullable: true, type: 'timestamp' })
+    kycVerifiedAt: Date | null;
+
+    @Column({ nullable: true })
+    kycDocumentUrl: string | null;
+
+    @Column({ nullable: true })
+    kycRejectionReason: string | null;
 
     @CreateDateColumn()
     createdAt: Date;

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,10 +1,13 @@
-import { Controller, Post, Body, UseGuards, Request, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards, Request, HttpCode, HttpStatus, Patch, Param, ForbiddenException } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from '../auth/auth.service';
 import { ChangePasswordDto } from './dtos/change-password.dto';
 import { ForgotPasswordDto } from './dtos/forgot-password.dto';
 import { ResetPasswordDto } from './dtos/reset-password.dto';
+import { SubmitKYCDto } from './dtos/submit-kyc.dto';
+import { UpdateKYCDto } from './dtos/update-kyc.dto';
 import { Public } from '../auth/decorators/public.decorator';
+import { UserRole } from './entities/user.entity';
 
 @Controller('users')
 export class UsersController {
@@ -30,5 +33,29 @@ export class UsersController {
   @HttpCode(HttpStatus.OK)
   async resetPassword(@Body() resetDto: ResetPasswordDto) {
     return this.authService.resetPassword(resetDto.token, resetDto.newPassword);
+  }
+
+  @UseGuards(AuthGuard('jwt'))
+  @Post('kyc/submit')
+  @HttpCode(HttpStatus.OK)
+  async submitKYC(@Request() req, @Body() submitKYCDto: SubmitKYCDto) {
+    const user = req.user;
+    return this.authService.submitKYC(user.id, submitKYCDto);
+  }
+
+  // Admin endpoint to update KYC status
+  @UseGuards(AuthGuard('jwt'))
+  @Patch('admin/kyc/:userId')
+  @HttpCode(HttpStatus.OK)
+  async updateKYCStatus(
+    @Request() req,
+    @Param('userId') userId: string,
+    @Body() updateKYCDto: UpdateKYCDto,
+  ) {
+    // Check if requester is admin
+    if (req.user.role !== UserRole.ADMIN) {
+      throw new ForbiddenException('Admin access required');
+    }
+    return this.authService.updateKYCStatus(userId, updateKYCDto);
   }
 }


### PR DESCRIPTION
Closes #31 
# Implement User KYC Status Management

## Description
This PR introduces endpoints and schema updates for managing user KYC (Know Your Customer) verification status. It enables both users and admins to handle KYC submissions, approvals, and rejections, with full tracking and notifications.

## Tasks
- Add KYC fields to user schema:  
  - `status` (enum: NONE, PENDING, APPROVED, REJECTED)  
  - `submitted_at`  
  - `verified_at`  
- Create `POST /users/kyc/submit` endpoint for user submissions  
- Create `UpdateKYCDto` for document uploads  
- Add admin endpoint: `PATCH /admin/users/:id/kyc` for approval/rejection  
- Send notification on status change  

## Acceptance Criteria
- [x] Users can submit KYC documents  
- [x] Admins can approve/reject KYC requests  
- [x] Status changes are tracked with timestamps (`submitted_at`, `verified_at`)  
- [x] Users receive email notifications on status change  

## Labels
- kyc  
- backend  
- user-management  
- compliance