### PR TITLE
feat: complete projects module schema with donations relation and ind…

### DIFF
--- a/src/projects/entities/donation.entity.ts
+++ b/src/projects/entities/donation.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { Project } from './project.entity';
+
+@Entity('donations')
+@Index('IDX_donations_project_id', ['projectId'])
+@Index('IDX_donations_donor_id', ['donorId'])
+export class Donation {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  projectId: string;
+
+  @ManyToOne(() => Project, (project) => project.donations, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'projectId' })
+  project: Project;
+
+  @Column({ nullable: true })
+  donorId: string | null;
+
+  @ManyToOne(() => User, { nullable: true, eager: false, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'donorId' })
+  donor: User | null;
+
+  @Column({ type: 'decimal', precision: 18, scale: 7 })
+  amount: number;
+
+  @Column({ nullable: true })
+  transactionHash: string | null;
+
+  @Column({ default: false })
+  isAnonymous: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/projects/entities/project.entity.ts
+++ b/src/projects/entities/project.entity.ts
@@ -7,8 +7,10 @@ import {
   ManyToOne,
   OneToMany,
   JoinColumn,
+  Index,
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
+import { Donation } from './donation.entity';
 
 export enum ProjectStatus {
   DRAFT = 'draft',
@@ -20,8 +22,9 @@ export enum ProjectStatus {
 }
 
 export enum ProjectCategory {
-  EDUCATION = 'education',
   HEALTH = 'health',
+  EDUCATION = 'education',
+  DISASTER_RELIEF = 'disaster_relief',
   ENVIRONMENT = 'environment',
   COMMUNITY = 'community',
   TECHNOLOGY = 'technology',
@@ -30,6 +33,8 @@ export enum ProjectCategory {
 }
 
 @Entity('projects')
+@Index('IDX_projects_creator_id', ['creatorId'])
+@Index('IDX_projects_status', ['status'])
 export class Project {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -39,6 +44,9 @@ export class Project {
 
   @Column({ type: 'text' })
   description: string;
+
+  @Column({ nullable: true })
+  imageUrl: string | null;
 
   @Column({
     type: 'enum',
@@ -60,18 +68,22 @@ export class Project {
   @Column({ type: 'decimal', precision: 18, scale: 7, default: 0 })
   fundsRaised: number;
 
-  @Column({ nullable: true })
-  imageUrl: string | null;
-
   @Column({ nullable: true, type: 'timestamp' })
   deadline: Date | null;
 
+  @Column({ nullable: true, type: 'text' })
+  rejectionReason: string | null;
+
+  @Index('IDX_projects_creator_id_col')
   @Column()
   creatorId: string;
 
-  @ManyToOne(() => User, { eager: false })
+  @ManyToOne(() => User, { eager: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'creatorId' })
   creator: User;
+
+  @OneToMany(() => Donation, (donation) => donation.project, { cascade: true })
+  donations: Donation[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/projects/projects.module.ts
+++ b/src/projects/projects.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Project } from './entities/project.entity';
+import { Donation } from './entities/donation.entity';
 import { ProjectsService } from './projects.service';
 import { ProjectsController } from './projects.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Project])],
+  imports: [TypeOrmModule.forFeature([Project, Donation])],
   controllers: [ProjectsController],
   providers: [ProjectsService],
+  exports: [ProjectsService],
 })
 export class ProjectsModule {}


### PR DESCRIPTION
## Summary

- Completes the projects module schema as defined in issue #37
- Expands `ProjectCategory` enum to include `DISASTER_RELIEF` alongside HEALTH, EDUCATION, ENVIRONMENT, COMMUNITY, TECHNOLOGY, ARTS, OTHER
- Adds proper database indexes on `creatorId` and `status` for query performance
- Introduces `Donation` entity with full schema and indexes on `projectId` and `donorId`
- Adds `OneToMany` donations relation on `Project` and `ManyToOne` back-reference on `Donation`
- Adds `rejectionReason` field to `Project` for admin feedback on rejected projects
- TypeORM `synchronize: true` handles table creation automatically (no manual migration needed in dev)

## Files Changed

- `src/projects/entities/project.entity.ts` — Expanded enums, added indexes, donations relation, rejectionReason, onDelete CASCADE
- `src/projects/entities/donation.entity.ts` — New entity: donations table with donor (nullable for anonymous), amount, transactionHash
- `src/projects/projects.module.ts` — Registered Donation entity, exported ProjectsService

## Schema Overview

### `projects` table

| Column | Type | Notes |
|---|---|---|
| id | uuid | PK |
| title | varchar | required |
| description | text | required |
| imageUrl | varchar | nullable |
| category | enum | HEALTH, EDUCATION, DISASTER_RELIEF, ENVIRONMENT, COMMUNITY, TECHNOLOGY, ARTS, OTHER |
| status | enum | DRAFT, PENDING, APPROVED, ACTIVE, COMPLETED, REJECTED |
| goalAmount | decimal(18,7) | required |
| fundsRaised | decimal(18,7) | default 0 |
| deadline | timestamp | nullable |
| rejectionReason | text | nullable |
| creatorId | uuid | FK → users(id), indexed |
| createdAt | timestamp | auto |
| updatedAt | timestamp | auto |

**Indexes:** `IDX_projects_creator_id`, `IDX_projects_status`

### `donations` table

| Column | Type | Notes |
|---|---|---|
| id | uuid | PK |
| projectId | uuid | FK → projects(id) ON DELETE CASCADE, indexed |
| donorId | uuid | FK → users(id) ON DELETE SET NULL, nullable (anonymous) |
| amount | decimal(18,7) | required |
| transactionHash | varchar | nullable (Stellar tx hash) |
| isAnonymous | boolean | default false |
| createdAt | timestamp | auto |

**Indexes:** `IDX_donations_project_id`, `IDX_donations_donor_id`

closes #37
