### PR TITLE
feat: create users module and entity schema

### DIFF
--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, Index } from 'typeorm';
 
 export enum UserRole {
     USER = 'user',
@@ -15,6 +15,8 @@ export enum KYCStatus {
 }
 
 @Entity('users')
+@Index('IDX_users_email', ['email'])
+@Index('IDX_users_wallet_address', ['walletAddress'])
 export class User {
     @PrimaryGeneratedColumn('uuid')
     id: string;
@@ -22,7 +24,7 @@ export class User {
     @Column({ unique: true })
     email: string;
 
-    @Column()
+    @Column({ name: 'password_hash' })
     password: string;
 
     @Column()
@@ -31,7 +33,7 @@ export class User {
     @Column()
     lastName: string;
 
-    @Column({ nullable: true })
+    @Column({ nullable: true, unique: true })
     walletAddress: string | null;
 
     @Column({

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
 import { AuthModule } from '../auth/auth.module';
 import { User } from './entities/user.entity';
 
@@ -10,5 +11,7 @@ import { User } from './entities/user.entity';
     TypeOrmModule.forFeature([User]),
   ],
   controllers: [UsersController],
+  providers: [UsersService],
+  exports: [UsersService, TypeOrmModule],
 })
 export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from './entities/user.entity';
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  async findById(id: string): Promise<User> {
+    const user = await this.userRepository.findOne({ where: { id } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+    return user;
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    return this.userRepository.findOne({ where: { email } });
+  }
+
+  async updateWalletAddress(userId: string, walletAddress: string): Promise<User> {
+    const user = await this.findById(userId);
+    user.walletAddress = walletAddress;
+    return this.userRepository.save(user);
+  }
+}


### PR DESCRIPTION
Description:

  Sets up the users module with a proper schema and service layer.

  The User entity already had the basic shape but was missing a few things — the password column wasn't named
  password_hash in the database, walletAddress had no uniqueness constraint, and neither field had dedicated indexes. This   PR addresses all of that.

  Named indexes (IDX_users_email, IDX_users_wallet_address) are added at the class level following the same pattern used  
  in the projects entity. The password TypeScript property now maps to a password_hash column in the DB without touching  
  any of the auth service logic that references it.

  A UsersService is introduced with findById, findByEmail, and updateWalletAddress — basic operations other modules can   
  build on. The module now exports both the service and TypeOrmModule so downstream modules can inject either without     
  re-declaring the feature.

  Schema changes will be picked up automatically on next startup via TypeORM's synchronize.

closes #26 