### PR TITLE
Implement admin user management features including user retrieval, role updates, and soft deletion

### DIFF
--- a/src/users/admin-users.controller.ts
+++ b/src/users/admin-users.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Query,
+  UseGuards,
+  Body,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Roles } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { UserRole } from './entities/user.entity';
+import { UsersService } from './users.service';
+import { AdminGetUsersQueryDto } from './dtos/admin-get-users-query.dto';
+import { UpdateUserRoleDto } from './dtos/update-user-role.dto';
+
+@ApiTags('Users')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(RolesGuard)
+@Roles(UserRole.ADMIN)
+@Controller('admin/users')
+export class AdminUsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get users with pagination and filters (Admin only)' })
+  @ApiResponse({ status: 200, description: 'Users retrieved successfully' })
+  async findAll(@Query() query: AdminGetUsersQueryDto) {
+    const { data, total } = await this.usersService.findAllForAdmin(query);
+    return {
+      data,
+      total,
+      limit: query.limit ?? 10,
+      offset: query.offset ?? 0,
+    };
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get user by ID (Admin only)' })
+  @ApiParam({ name: 'id', description: 'User ID' })
+  @ApiResponse({ status: 200, description: 'User retrieved successfully' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async findOne(@Param('id') id: string) {
+    return this.usersService.getUserByIdForAdmin(id);
+  }
+
+  @Patch(':id/role')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Update user role (Admin only)' })
+  @ApiParam({ name: 'id', description: 'User ID' })
+  @ApiResponse({ status: 200, description: 'User role updated successfully' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async updateRole(
+    @Param('id') id: string,
+    @Body() dto: UpdateUserRoleDto,
+  ) {
+    return this.usersService.updateUserRole(id, dto.role);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Soft delete user by ID (Admin only)' })
+  @ApiParam({ name: 'id', description: 'User ID' })
+  @ApiResponse({ status: 200, description: 'User soft-deleted successfully' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async softDelete(@Param('id') id: string) {
+    return this.usersService.softDeleteUser(id);
+  }
+}

--- a/src/users/dtos/admin-get-users-query.dto.ts
+++ b/src/users/dtos/admin-get-users-query.dto.ts
@@ -1,0 +1,60 @@
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, Matches, Max, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { KYCStatus, UserRole } from '../entities/user.entity';
+
+export class AdminGetUsersQueryDto {
+  @ApiPropertyOptional({
+    description: 'Filter users by role',
+    enum: UserRole,
+    example: UserRole.USER,
+  })
+  @IsOptional()
+  @IsEnum(UserRole)
+  role?: UserRole;
+
+  @ApiPropertyOptional({
+    name: 'kyc_status',
+    description: 'Filter users by KYC status',
+    enum: KYCStatus,
+    example: KYCStatus.PENDING,
+  })
+  @IsOptional()
+  @IsEnum(KYCStatus)
+  kyc_status?: KYCStatus;
+
+  @ApiPropertyOptional({
+    name: 'created_date',
+    description: 'Filter users created on a specific date (YYYY-MM-DD)',
+    example: '2026-02-25',
+  })
+  @IsOptional()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  created_date?: string;
+
+  @ApiPropertyOptional({
+    description: 'Number of results per page',
+    minimum: 1,
+    maximum: 100,
+    default: 10,
+    example: 10,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 10;
+
+  @ApiPropertyOptional({
+    description: 'Number of results to skip (for pagination)',
+    minimum: 0,
+    default: 0,
+    example: 0,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number = 0;
+}

--- a/src/users/dtos/update-user-role.dto.ts
+++ b/src/users/dtos/update-user-role.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { UserRole } from '../entities/user.entity';
+
+export class UpdateUserRoleDto {
+  @ApiProperty({
+    description: 'New role for the user',
+    enum: UserRole,
+    example: UserRole.CREATOR,
+  })
+  @IsEnum(UserRole)
+  role: UserRole;
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   Index,
+  DeleteDateColumn,
 } from 'typeorm';
 
 export enum UserRole {
@@ -104,4 +105,7 @@ export class User {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  @DeleteDateColumn({ nullable: true })
+  deletedAt: Date | null;
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -4,11 +4,13 @@ import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { AuthModule } from '../auth/auth.module';
 import { User } from './entities/user.entity';
+import { AdminUsersController } from './admin-users.controller';
+import { RolesGuard } from '../common/guards/roles.guard';
 
 @Module({
   imports: [AuthModule, TypeOrmModule.forFeature([User])],
-  controllers: [UsersController],
-  providers: [UsersService],
+  controllers: [UsersController, AdminUsersController],
+  providers: [UsersService, RolesGuard],
   exports: [UsersService, TypeOrmModule],
 })
 export class UsersModule {}


### PR DESCRIPTION
Adds minimal admin-only user management APIs:

- `GET /admin/users` with pagination (`limit`, `offset`) and filters (`role`, `kyc_status`, `created_date`)
- `GET /admin/users/:id`
- `PATCH /admin/users/:id/role`
- `DELETE /admin/users/:id` as soft delete (`deletedAt`)

All routes are protected with admin role guard, pagination/filtering are applied in service query logic, and soft delete preserves user data.

Closes #32.