### PR TITLE
feat: add GET /users/donations endpoint for user donation history

### DIFF
--- a/src/donations/dto/get-user-donations-query.dto.ts
+++ b/src/donations/dto/get-user-donations-query.dto.ts
@@ -1,0 +1,45 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsInt, Min, Max, IsDateString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GetUserDonationsQueryDto {
+  @ApiPropertyOptional({
+    example: 1,
+    description: 'Page number (default: 1)',
+    minimum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    example: 10,
+    description: 'Number of items per page (default: 10, max: 100)',
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 10;
+
+  @ApiPropertyOptional({
+    example: '2024-01-01',
+    description: 'Start date for filtering donations (ISO 8601 format)',
+  })
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @ApiPropertyOptional({
+    example: '2024-12-31',
+    description: 'End date for filtering donations (ISO 8601 format)',
+  })
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+}

--- a/src/donations/dto/user-donation-history-response.dto.ts
+++ b/src/donations/dto/user-donation-history-response.dto.ts
@@ -1,0 +1,150 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Donation } from '../entities/donation.entity';
+
+export class ProjectInfoDto {
+  @ApiProperty({ example: 'project-uuid', description: 'Project ID' })
+  id: string;
+
+  @ApiProperty({ example: 'Education Fund', description: 'Project title' })
+  title: string;
+
+  @ApiProperty({
+    example: 'https://example.com/project-image.jpg',
+    nullable: true,
+    description: 'Project image URL',
+  })
+  imageUrl: string | null;
+
+  @ApiProperty({ example: 'education', description: 'Project category' })
+  category: string;
+
+  @ApiProperty({ example: 'active', description: 'Project status' })
+  status: string;
+}
+
+export class UserDonationItemDto {
+  @ApiProperty({ example: 'donation-uuid', description: 'Donation ID' })
+  id: string;
+
+  @ApiProperty({ example: 100, description: 'Donation amount' })
+  amount: number;
+
+  @ApiProperty({ example: 'XLM', description: 'Asset type' })
+  assetType: string;
+
+  @ApiProperty({
+    example: 'transaction-hash-xyz',
+    nullable: true,
+    description: 'Blockchain transaction hash',
+  })
+  transactionHash: string | null;
+
+  @ApiProperty({
+    example: 'https://stellar.expert/explorer/public/tx/transaction-hash-xyz',
+    nullable: true,
+    description: 'Blockchain explorer link',
+  })
+  blockchainExplorerUrl: string | null;
+
+  @ApiProperty({
+    example: false,
+    description: 'Whether donation is anonymous',
+  })
+  isAnonymous: boolean;
+
+  @ApiProperty({
+    example: 'verified',
+    description: 'Transaction status',
+    enum: ['pending', 'verified', 'failed'],
+  })
+  transactionStatus: string;
+
+  @ApiProperty({
+    example: '2024-01-01T00:00:00Z',
+    description: 'Donation timestamp',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    type: ProjectInfoDto,
+    nullable: true,
+    description: 'Project information',
+  })
+  project: ProjectInfoDto | null;
+
+  static fromEntity(
+    donation: Donation,
+    blockchainExplorerBaseUrl: string = 'https://stellar.expert/explorer/public/tx',
+  ): UserDonationItemDto {
+    return {
+      id: donation.id,
+      amount: Number(donation.amount),
+      assetType: donation.assetType,
+      transactionHash: donation.transactionHash,
+      blockchainExplorerUrl: donation.transactionHash
+        ? `${blockchainExplorerBaseUrl}/${donation.transactionHash}`
+        : null,
+      isAnonymous: donation.isAnonymous,
+      transactionStatus: donation.transactionHash ? 'verified' : 'pending',
+      createdAt: donation.createdAt,
+      project: donation.project
+        ? ({
+            id: donation.project.id,
+            title: donation.project.title,
+            imageUrl: donation.project.imageUrl,
+            category: donation.project.category,
+            status: donation.project.status,
+          } as ProjectInfoDto)
+        : null,
+    };
+  }
+}
+
+export class UserDonationSummaryDto {
+  @ApiProperty({ example: 50, description: 'Total number of donations' })
+  totalDonations: number;
+
+  @ApiProperty({ example: 25000.5, description: 'Total amount donated' })
+  totalAmount: number;
+
+  @ApiProperty({ example: 500.01, description: 'Average donation amount' })
+  averageDonation: number;
+
+  @ApiProperty({ example: 10, description: 'Number of projects donated to' })
+  projectsSupported: number;
+
+  @ApiProperty({
+    example: '2024-01-01T00:00:00Z',
+    description: 'First donation date',
+  })
+  firstDonationDate: Date | null;
+
+  @ApiProperty({
+    example: '2024-12-31T00:00:00Z',
+    description: 'Last donation date',
+  })
+  lastDonationDate: Date | null;
+}
+
+export class UserDonationHistoryResponseDto {
+  @ApiProperty({
+    type: [UserDonationItemDto],
+    description: 'List of user donations',
+  })
+  data: UserDonationItemDto[];
+
+  @ApiProperty({ example: 50, description: 'Total number of donations' })
+  total: number;
+
+  @ApiProperty({ example: 1, description: 'Current page' })
+  page: number;
+
+  @ApiProperty({ example: 10, description: 'Items per page' })
+  limit: number;
+
+  @ApiProperty({
+    type: UserDonationSummaryDto,
+    description: 'Donation summary statistics',
+  })
+  summary: UserDonationSummaryDto;
+}

--- a/src/donations/providers/donations.service.ts
+++ b/src/donations/providers/donations.service.ts
@@ -17,6 +17,11 @@ import {
   ProjectDonationItemDto,
   ProjectDonationsStatsDto,
 } from '../dto/project-donations-response.dto';
+import {
+  UserDonationHistoryResponseDto,
+  UserDonationItemDto,
+  UserDonationSummaryDto,
+} from '../dto/user-donation-history-response.dto';
 import { StellarBlockchainService } from '../../common/services/stellar-blockchain.service';
 import { MailService } from '../../mail/mail.service';
 
@@ -356,6 +361,105 @@ export class DonationsService {
       totalAmount,
       averageDonation: totalDonations > 0 ? totalAmount / totalDonations : 0,
       uniqueDonors,
+    };
+  }
+
+  async getUserDonationHistory(
+    userId: string,
+    page: number = 1,
+    limit: number = 10,
+    startDate?: string,
+    endDate?: string,
+  ): Promise<UserDonationHistoryResponseDto> {
+    // Build query with date filters
+    const queryBuilder = this.donationsRepository
+      .createQueryBuilder('donation')
+      .leftJoinAndSelect('donation.project', 'project')
+      .where('donation.donorId = :userId', { userId })
+      .orderBy('donation.createdAt', 'DESC');
+
+    // Apply date range filters if provided
+    if (startDate) {
+      queryBuilder.andWhere('donation.createdAt >= :startDate', {
+        startDate: new Date(startDate),
+      });
+    }
+
+    if (endDate) {
+      queryBuilder.andWhere('donation.createdAt <= :endDate', {
+        endDate: new Date(endDate),
+      });
+    }
+
+    // Get total count for pagination
+    const total = await queryBuilder.getCount();
+
+    // Get paginated donations
+    const donations = await queryBuilder
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getMany();
+
+    // Calculate summary statistics
+    const summary = await this.calculateUserDonationSummary(userId, startDate, endDate);
+
+    // Transform donations to DTOs
+    const donationItems: UserDonationItemDto[] = donations.map((donation) =>
+      UserDonationItemDto.fromEntity(donation),
+    );
+
+    return {
+      data: donationItems,
+      total,
+      page,
+      limit,
+      summary,
+    };
+  }
+
+  private async calculateUserDonationSummary(
+    userId: string,
+    startDate?: string,
+    endDate?: string,
+  ): Promise<UserDonationSummaryDto> {
+    const queryBuilder = this.donationsRepository
+      .createQueryBuilder('donation')
+      .select('COUNT(donation.id)', 'totalDonations')
+      .addSelect('SUM(donation.amount)', 'totalAmount')
+      .addSelect('COUNT(DISTINCT donation.projectId)', 'projectsSupported')
+      .addSelect('MIN(donation.createdAt)', 'firstDonationDate')
+      .addSelect('MAX(donation.createdAt)', 'lastDonationDate')
+      .where('donation.donorId = :userId', { userId });
+
+    // Apply date range filters if provided
+    if (startDate) {
+      queryBuilder.andWhere('donation.createdAt >= :startDate', {
+        startDate: new Date(startDate),
+      });
+    }
+
+    if (endDate) {
+      queryBuilder.andWhere('donation.createdAt <= :endDate', {
+        endDate: new Date(endDate),
+      });
+    }
+
+    const result = await queryBuilder.getRawOne();
+
+    const totalDonations = parseInt(result.totalDonations, 10) || 0;
+    const totalAmount = parseFloat(result.totalAmount) || 0;
+
+    return {
+      totalDonations,
+      totalAmount,
+      averageDonation: totalDonations > 0 ? totalAmount / totalDonations : 0,
+      projectsSupported: parseInt(result.projectsSupported, 10) || 0,
+      firstDonationDate: result.firstDonationDate
+        ? new Date(result.firstDonationDate)
+        : null,
+      lastDonationDate: result.lastDonationDate
+        ? new Date(result.lastDonationDate)
+        : null,
     };
   }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -10,6 +10,7 @@ import {
   Patch,
   Param,
   ForbiddenException,
+  Query,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import {
@@ -25,12 +26,15 @@ import { ResetPasswordDto } from './dto/reset-password.dto';
 import { SubmitKYCDto } from './dto/submit-kyc.dto';
 import { UpdateKYCDto } from './dto/update-kyc.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { GetUserDonationsQueryDto } from '../donations/dto/get-user-donations-query.dto';
+import { UserDonationHistoryResponseDto } from '../donations/dto/user-donation-history-response.dto';
 import { Public } from '../common/decorators/public.decorator';
 import type { JwtPayload } from '../common/interfaces/auth.interface';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { UserRole } from 'src/common/enums/user-role.enum';
 import { AuthService } from 'src/auth/providers/auth.service';
 import { UsersService } from './providers/users.service';
+import { DonationsService } from '../donations/providers/donations.service';
 
 @ApiTags('Users')
 @Controller('users')
@@ -38,6 +42,7 @@ export class UsersController {
   constructor(
     private readonly authService: AuthService,
     private readonly usersService: UsersService,
+    private readonly donationsService: DonationsService,
   ) {}
 
   @UseGuards(AuthGuard('jwt'))
@@ -132,5 +137,34 @@ export class UsersController {
       throw new ForbiddenException('Admin access required');
     }
     return this.authService.updateKYCStatus(userId, updateKYCDto);
+  }
+
+  //_____________________ Endpoint to get current user's donation history
+  @Get('donations')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth('JWT-auth')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: "Get current user's donation history",
+    description:
+      'Returns paginated list of user donations with project information and summary statistics',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Donation history retrieved successfully',
+    type: UserDonationHistoryResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getUserDonations(
+    @CurrentUser() user: JwtPayload,
+    @Query() query: GetUserDonationsQueryDto,
+  ): Promise<UserDonationHistoryResponseDto> {
+    return this.donationsService.getUserDonationHistory(
+      user.sub,
+      query.page,
+      query.limit,
+      query.startDate,
+      query.endDate,
+    );
   }
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -6,9 +6,10 @@ import { User } from './entities/user.entity';
 import { AdminUsersController } from './admin-users.controller';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { UsersService } from './providers/users.service';
+import { DonationsModule } from '../donations/donations.module';
 
 @Module({
-  imports: [AuthModule, TypeOrmModule.forFeature([User])],
+  imports: [AuthModule, TypeOrmModule.forFeature([User]), DonationsModule],
   controllers: [UsersController, AdminUsersController],
   providers: [UsersService, RolesGuard],
   exports: [UsersService, TypeOrmModule],


### PR DESCRIPTION
Closes #85

---

## Description
Implements a new authenticated endpoint for users to view their complete donation history with project details, transaction status, and lifetime statistics.

## Changes
- **New DTOs:**
  - `UserDonationHistoryResponseDto` - Main response with paginated donations and summary
  - `UserDonationItemDto` - Individual donation with project info and transaction status
  - `ProjectInfoDto` - Project details (id, title, image, category, status)
  - `UserDonationSummaryDto` - Lifetime donation statistics
  - `GetUserDonationsQueryDto` - Query parameters with date range filters

- **Service Updates:**
  - Added `getUserDonationHistory()` to fetch paginated donations with filters
  - Added `calculateUserDonationSummary()` for lifetime metrics

- **Controller:**
  - Added `GET /users/donations` endpoint (JWT protected)

- **Module:**
  - Imported `DonationsModule` into `UsersModule`

## API Specification
- **Endpoint:** `GET /users/donations`
- **Authentication:** JWT required
- **Query Parameters:**
  - `page` (optional, default: 1, min: 1)
  - `limit` (optional, default: 10, max: 100)
  - `startDate` (optional, ISO 8601 format)
  - `endDate` (optional, ISO 8601 format)
- **Response:** Paginated donation list with project details and summary statistics

## Acceptance Criteria
| Criteria | Status |
|----------|--------|
| Returns user's donation history | ✅ |
| Includes project details for each donation | ✅ |
| Filterable by date range | ✅ |
| Shows lifetime donation total | ✅ |

## Features
- JWT authentication required
- Pagination support
- Date range filtering
- Project information included for each donation
- Transaction status (verified/pending)
- Blockchain explorer links
- Lifetime statistics (total donations, amount, average, projects supported)

close issue #85 