### PR TITLE
feat: implement role-based access control (RBAC) system

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
-import { Public, CurrentUser } from './modules/auth';
+import { Public, CurrentUser, Roles } from './modules/auth';
+import { UserRole } from './modules/auth/types/user-role.enum';
 
 @Controller()
 export class AppController {
@@ -16,6 +17,33 @@ export class AppController {
   getProtected(@CurrentUser() user: any): any {
     return {
       message: 'This is a protected route',
+      user: user,
+    };
+  }
+
+  @Roles(UserRole.ADMIN)
+  @Get('admin-only')
+  getAdminOnly(@CurrentUser() user: any): any {
+    return {
+      message: 'This route is only accessible by admins',
+      user: user,
+    };
+  }
+
+  @Roles(UserRole.CREATOR, UserRole.ADMIN)
+  @Get('creator-admin')
+  getCreatorAdmin(@CurrentUser() user: any): any {
+    return {
+      message: 'This route is accessible by creators and admins',
+      user: user,
+    };
+  }
+
+  @Roles(UserRole.DONOR, UserRole.ADMIN)
+  @Get('donor-admin')
+  getDonorAdmin(@CurrentUser() user: any): any {
+    return {
+      message: 'This route is accessible by donors and admins',
       user: user,
     };
   }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,7 +8,7 @@ import { RequestLoggerMiddleware } from './common/middleware';
 import { winstonConfig } from './config/winston.config';
 import { AppConfigurationModule } from './config/app-configuration.module';
 import { AuthModule } from './modules/auth/auth.module';
-import { JwtAuthGuard } from './modules/auth';
+import { JwtAuthGuard, RolesGuard } from './modules/auth';
 
 @Module({
   imports: [
@@ -21,6 +21,9 @@ import { JwtAuthGuard } from './modules/auth';
   providers: [AppService, {
     provide: APP_GUARD,
     useClass: JwtAuthGuard,
+  }, {
+    provide: APP_GUARD,
+    useClass: RolesGuard,
   }],
 })
 export class AppModule implements NestModule {

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { RolesGuard } from './guards/roles.guard';
 import { PrismaModule } from '../../database/prisma.module';
 import { AppConfigService } from '../../config/app-config.service';
 
@@ -21,7 +22,7 @@ import { AppConfigService } from '../../config/app-config.service';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, JwtAuthGuard],
-  exports: [AuthService],
+  providers: [AuthService, JwtStrategy, JwtAuthGuard, RolesGuard],
+  exports: [AuthService, JwtAuthGuard, RolesGuard],
 })
 export class AuthModule {}

--- a/src/modules/auth/decorators/index.ts
+++ b/src/modules/auth/decorators/index.ts
@@ -1,2 +1,3 @@
 export * from './current-user.decorator';
 export * from './public.decorator';
+export * from './roles.decorator';

--- a/src/modules/auth/decorators/roles.decorator.ts
+++ b/src/modules/auth/decorators/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from '../types/user-role.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/modules/auth/guards/index.ts
+++ b/src/modules/auth/guards/index.ts
@@ -1,1 +1,2 @@
 export * from './jwt-auth.guard';
+export * from './roles.guard';

--- a/src/modules/auth/guards/roles.guard.ts
+++ b/src/modules/auth/guards/roles.guard.ts
@@ -1,0 +1,36 @@
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { UserRole } from '../types/user-role.enum';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles) {
+      return true; // No roles required, allow access
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+
+    if (!user) {
+      throw new ForbiddenException('User not found in request');
+    }
+
+    const hasRole = requiredRoles.some((role) => user.role === role);
+
+    if (!hasRole) {
+      throw new ForbiddenException(
+        `Insufficient permissions. Required roles: ${requiredRoles.join(', ')}`
+      );
+    }
+
+    return true;
+  }
+}

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -3,3 +3,4 @@ export * from './dto/login.dto';
 export * from './interfaces/auth.interface';
 export * from './guards';
 export * from './decorators';
+export * from './strategies/jwt.strategy';

--- a/src/modules/auth/types/user-role.enum.ts
+++ b/src/modules/auth/types/user-role.enum.ts
@@ -1,0 +1,6 @@
+export enum UserRole {
+  USER = 'USER',
+  ADMIN = 'ADMIN',
+  CREATOR = 'CREATOR',
+  DONOR = 'DONOR',
+}


### PR DESCRIPTION
- Closes #136

- Create RolesGuard for role-based route protection
- Add @Roles() decorator to specify required roles for routes
- Define UserRole enum (USER, ADMIN, CREATOR, DONOR) locally
- Implement role validation logic in guard
- Set up global RolesGuard alongside JWT guard
- Add role-restricted example routes (admin-only, creator-admin, donor-admin)
- Combine seamlessly with existing JWT authentication
- Return 403 Forbidden for unauthorized role access
- Maintain backward compatibility with existing auth system
- Export guards and decorators from auth module for easy usage