### PR TITLE
feat: resolve issues #141, #142, #143, #144

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,8 +1,6 @@
 // This is your Prisma schema file,
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
-// Get a free hosted Postgres database in seconds: `npx create-db`
-
 generator client {
   provider = "prisma-client-js"
   output   = "../generated/prisma"
@@ -12,7 +10,8 @@ datasource db {
   provider = "postgresql"
 }
 
-// User model for authentication
+// ── Enums ─────────────────────────────────────────────────────────────────────
+
 enum UserRole {
   USER
   ADMIN
@@ -27,25 +26,59 @@ enum UserStatus {
   DELETED
 }
 
+enum KycStatus {
+  NONE
+  PENDING
+  APPROVED
+  REJECTED
+}
+
+enum ProjectStatus {
+  PENDING
+  APPROVED
+  REJECTED
+  ACTIVE
+  COMPLETED
+}
+
+enum ProjectCategory {
+  HEALTH
+  EDUCATION
+  DISASTER_RELIEF
+  ENVIRONMENT
+  POVERTY
+  HUMAN_RIGHTS
+  COMMUNITY
+  OTHER
+}
+
+// ── Models ────────────────────────────────────────────────────────────────────
+
 model User {
-  id               String          @id @default(uuid())
-  email            String          @unique
+  id               String        @id @default(uuid())
+  email            String        @unique
   password         String
   firstName        String?
   lastName         String?
   country          String?
   bio              String?
   avatar           String?
-  role             UserRole        @default(USER)
-  status           UserStatus      @default(PENDING)
-  isEmailVerified  Boolean         @default(false)
+  role             UserRole      @default(USER)
+  status           UserStatus    @default(PENDING)
+  isEmailVerified  Boolean       @default(false)
   emailVerifiedAt  DateTime?
-  walletAddress    String?         @unique
-  kycStatus        String?         @default("NOT_SUBMITTED")
-  createdAt        DateTime        @default(now())
-  updatedAt        DateTime        @updatedAt
+  walletAddress    String?       @unique
+  // KYC fields (Issue #142)
+  kycStatus        KycStatus     @default(NONE)
+  kycDocumentUrl   String?
+  kycSubmittedAt   DateTime?
+  kycVerifiedAt    DateTime?
+  deletedAt        DateTime?
+  createdAt        DateTime      @default(now())
+  updatedAt        DateTime      @updatedAt
   refreshTokens    RefreshToken[]
   emailTokens      EmailToken[]
+  projects         Project[]
 
   @@map("users")
   @@index([role])
@@ -76,4 +109,31 @@ model EmailToken {
   createdAt DateTime @default(now())
 
   @@map("email_tokens")
+}
+
+// Issue #144: Projects model
+model Project {
+  id              String          @id @default(uuid())
+  title           String
+  description     String
+  category        ProjectCategory
+  status          ProjectStatus   @default(PENDING)
+  goalAmount      Decimal         @db.Decimal(18, 7)
+  raisedAmount    Decimal         @default(0) @db.Decimal(18, 7)
+  imageUrl        String?
+  walletAddress   String?
+  creatorId       String
+  creator         User            @relation(fields: [creatorId], references: [id])
+  startDate       DateTime?
+  endDate         DateTime?
+  approvedAt      DateTime?
+  rejectedAt      DateTime?
+  rejectionReason String?
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
+
+  @@map("projects")
+  @@index([creatorId])
+  @@index([status])
+  @@index([category])
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,8 @@ import { winstonConfig } from './config/winston.config';
 import { AppConfigurationModule } from './config/app-configuration.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { UsersModule } from './modules/users/users.module';
+import { AdminModule } from './modules/admin/admin.module';
+import { ProjectsModule } from './modules/projects/projects.module';
 import { JwtAuthGuard, RolesGuard } from './modules/auth';
 
 @Module({
@@ -17,6 +19,8 @@ import { JwtAuthGuard, RolesGuard } from './modules/auth';
     PrismaModule,
     AuthModule,
     UsersModule,
+    AdminModule,
+    ProjectsModule,
     WinstonModule.forRoot(winstonConfig),
   ],
   controllers: [AppController],

--- a/src/modules/admin/admin-users.controller.ts
+++ b/src/modules/admin/admin-users.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Controller,
+  Get,
+  Patch,
+  Delete,
+  Param,
+  Body,
+  Query,
+} from '@nestjs/common';
+import { AdminUsersService } from './admin-users.service';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../auth/types/user-role.enum';
+import { UpdateUserRoleDto } from './dto/update-user-role.dto';
+import { UpdateKycStatusDto } from './dto/update-kyc-status.dto';
+import { ListUsersQueryDto } from './dto/list-users-query.dto';
+
+@Controller('admin/users')
+@Roles(UserRole.ADMIN)
+export class AdminUsersController {
+  constructor(private readonly adminUsersService: AdminUsersService) {}
+
+  // Issue #143
+  @Get()
+  listUsers(@Query() query: ListUsersQueryDto) {
+    return this.adminUsersService.listUsers(query);
+  }
+
+  @Get(':id')
+  getUser(@Param('id') id: string) {
+    return this.adminUsersService.getUser(id);
+  }
+
+  @Patch(':id/role')
+  updateRole(@Param('id') id: string, @Body() dto: UpdateUserRoleDto) {
+    return this.adminUsersService.updateRole(id, dto.role);
+  }
+
+  @Delete(':id')
+  deleteUser(@Param('id') id: string) {
+    return this.adminUsersService.softDeleteUser(id);
+  }
+
+  // Issue #142
+  @Patch(':id/kyc')
+  updateKyc(@Param('id') id: string, @Body() dto: UpdateKycStatusDto) {
+    return this.adminUsersService.updateKycStatus(id, dto);
+  }
+}

--- a/src/modules/admin/admin-users.service.ts
+++ b/src/modules/admin/admin-users.service.ts
@@ -1,0 +1,88 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../database/prisma.service';
+import { EmailService } from '../users/email.service';
+import { KycStatus, UserRole, UserStatus } from '../../../generated/prisma';
+import { UpdateKycStatusDto } from './dto/update-kyc-status.dto';
+import { ListUsersQueryDto } from './dto/list-users-query.dto';
+
+@Injectable()
+export class AdminUsersService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly emailService: EmailService,
+  ) {}
+
+  async listUsers(query: ListUsersQueryDto) {
+    const { role, kycStatus, page = 1, limit = 20 } = query;
+    const skip = (page - 1) * limit;
+
+    const where: any = { deletedAt: null };
+    if (role) where.role = role;
+    if (kycStatus) where.kycStatus = kycStatus;
+
+    const [users, total] = await this.prisma.$transaction([
+      this.prisma.user.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true, email: true, firstName: true, lastName: true,
+          role: true, status: true, kycStatus: true, createdAt: true,
+        },
+      }),
+      this.prisma.user.count({ where }),
+    ]);
+
+    return { data: users, total, page, limit };
+  }
+
+  async getUser(id: string) {
+    const user = await this.prisma.user.findFirst({
+      where: { id, deletedAt: null },
+      select: {
+        id: true, email: true, firstName: true, lastName: true, country: true,
+        bio: true, avatar: true, role: true, status: true, isEmailVerified: true,
+        walletAddress: true, kycStatus: true, kycSubmittedAt: true,
+        kycVerifiedAt: true, createdAt: true, updatedAt: true,
+      },
+    });
+    if (!user) throw new NotFoundException('User not found');
+    return user;
+  }
+
+  async updateRole(id: string, role: UserRole) {
+    await this.getUser(id);
+    return this.prisma.user.update({ where: { id }, data: { role } });
+  }
+
+  async softDeleteUser(id: string) {
+    await this.getUser(id);
+    await this.prisma.user.update({
+      where: { id },
+      data: { deletedAt: new Date(), status: UserStatus.DELETED },
+    });
+    return { message: 'User deleted successfully' };
+  }
+
+  async updateKycStatus(id: string, dto: UpdateKycStatusDto) {
+    const user = await this.prisma.user.findFirst({ where: { id, deletedAt: null } });
+    if (!user) throw new NotFoundException('User not found');
+
+    const data: any = {
+      kycStatus: dto.status,
+      ...(dto.status === KycStatus.APPROVED && { kycVerifiedAt: new Date() }),
+      ...(dto.status === KycStatus.REJECTED && { kycVerifiedAt: null }),
+    };
+
+    const updated = await this.prisma.user.update({ where: { id }, data });
+
+    try {
+      await this.emailService.sendKycStatusEmail(user.email, dto.status);
+    } catch {
+      // non-blocking
+    }
+
+    return { message: `KYC status updated to ${dto.status}`, kycStatus: updated.kycStatus };
+  }
+}

--- a/src/modules/admin/admin.module.ts
+++ b/src/modules/admin/admin.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AdminUsersController } from './admin-users.controller';
+import { AdminUsersService } from './admin-users.service';
+import { PrismaModule } from '../../database/prisma.module';
+import { EmailService } from '../users/email.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [AdminUsersController],
+  providers: [AdminUsersService, EmailService],
+})
+export class AdminModule {}

--- a/src/modules/admin/dto/list-users-query.dto.ts
+++ b/src/modules/admin/dto/list-users-query.dto.ts
@@ -1,0 +1,26 @@
+import { IsEnum, IsInt, IsOptional, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { UserRole } from '../../auth/types/user-role.enum';
+import { KycStatus } from '../../../../generated/prisma';
+
+export class ListUsersQueryDto {
+  @IsOptional()
+  @IsEnum(UserRole)
+  role?: UserRole;
+
+  @IsOptional()
+  @IsEnum(KycStatus)
+  kycStatus?: KycStatus;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 20;
+}

--- a/src/modules/admin/dto/update-kyc-status.dto.ts
+++ b/src/modules/admin/dto/update-kyc-status.dto.ts
@@ -1,0 +1,11 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { KycStatus } from '../../../../generated/prisma';
+
+export class UpdateKycStatusDto {
+  @IsEnum(KycStatus)
+  status!: KycStatus;
+
+  @IsOptional()
+  @IsString()
+  rejectionReason?: string;
+}

--- a/src/modules/admin/dto/update-user-role.dto.ts
+++ b/src/modules/admin/dto/update-user-role.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { UserRole } from '../../auth/types/user-role.enum';
+
+export class UpdateUserRoleDto {
+  @IsEnum(UserRole)
+  role!: UserRole;
+}

--- a/src/modules/projects/dto/create-project.dto.ts
+++ b/src/modules/projects/dto/create-project.dto.ts
@@ -1,0 +1,33 @@
+import { IsEnum, IsNotEmpty, IsNumber, IsOptional, IsString, IsUrl, Min } from 'class-validator';
+import { ProjectCategory } from '../../../../generated/prisma';
+
+export class CreateProjectDto {
+  @IsString()
+  @IsNotEmpty()
+  title!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  description!: string;
+
+  @IsEnum(ProjectCategory)
+  category!: ProjectCategory;
+
+  @IsNumber()
+  @Min(1)
+  goalAmount!: number;
+
+  @IsOptional()
+  @IsUrl()
+  imageUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  walletAddress?: string;
+
+  @IsOptional()
+  startDate?: Date;
+
+  @IsOptional()
+  endDate?: Date;
+}

--- a/src/modules/projects/projects.controller.ts
+++ b/src/modules/projects/projects.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Post, Param, Body } from '@nestjs/common';
+import { ProjectsService } from './projects.service';
+import { CreateProjectDto } from './dto/create-project.dto';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+
+interface JwtUser { id: string }
+
+@Controller('projects')
+export class ProjectsController {
+  constructor(private readonly projectsService: ProjectsService) {}
+
+  @Post()
+  create(@CurrentUser() user: JwtUser, @Body() dto: CreateProjectDto) {
+    return this.projectsService.create(user.id, dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.projectsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.projectsService.findOne(id);
+  }
+}

--- a/src/modules/projects/projects.module.ts
+++ b/src/modules/projects/projects.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ProjectsController } from './projects.controller';
+import { ProjectsService } from './projects.service';
+import { PrismaModule } from '../../database/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ProjectsController],
+  providers: [ProjectsService],
+  exports: [ProjectsService],
+})
+export class ProjectsModule {}

--- a/src/modules/projects/projects.service.ts
+++ b/src/modules/projects/projects.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../database/prisma.service';
+import { CreateProjectDto } from './dto/create-project.dto';
+
+@Injectable()
+export class ProjectsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(creatorId: string, dto: CreateProjectDto) {
+    return this.prisma.project.create({
+      data: { ...dto, creatorId },
+    });
+  }
+
+  async findAll() {
+    return this.prisma.project.findMany({
+      orderBy: { createdAt: 'desc' },
+      include: { creator: { select: { id: true, firstName: true, lastName: true } } },
+    });
+  }
+
+  async findOne(id: string) {
+    const project = await this.prisma.project.findUnique({
+      where: { id },
+      include: { creator: { select: { id: true, firstName: true, lastName: true } } },
+    });
+    if (!project) throw new NotFoundException('Project not found');
+    return project;
+  }
+}

--- a/src/modules/users/dto/forgot-password.dto.ts
+++ b/src/modules/users/dto/forgot-password.dto.ts
@@ -1,0 +1,6 @@
+import { IsEmail } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @IsEmail()
+  email!: string;
+}

--- a/src/modules/users/dto/index.ts
+++ b/src/modules/users/dto/index.ts
@@ -1,2 +1,5 @@
 export * from './change-password.dto';
 export * from './update-user.dto';
+export * from './forgot-password.dto';
+export * from './reset-password.dto';
+export * from './submit-kyc.dto';

--- a/src/modules/users/dto/reset-password.dto.ts
+++ b/src/modules/users/dto/reset-password.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, MinLength } from 'class-validator';
+
+export class ResetPasswordDto {
+  @IsString()
+  token!: string;
+
+  @IsString()
+  @MinLength(8)
+  newPassword!: string;
+}

--- a/src/modules/users/dto/submit-kyc.dto.ts
+++ b/src/modules/users/dto/submit-kyc.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsUrl } from 'class-validator';
+
+export class SubmitKycDto {
+  @IsString()
+  @IsUrl()
+  documentUrl!: string;
+}

--- a/src/modules/users/dto/update-user.dto.ts
+++ b/src/modules/users/dto/update-user.dto.ts
@@ -1,44 +1,39 @@
-import { IsString, IsOptional, IsLength, Matches, IsIn } from 'class-validator';
+import { IsString, IsOptional, MaxLength, MinLength, Matches } from 'class-validator';
 
 export class UpdateUserDto {
   @IsOptional()
   @IsString()
-  @IsLength(1, 100, {
-    message: 'First name must be between 1 and 100 characters',
-  })
+  @MinLength(1)
+  @MaxLength(100)
   firstName?: string;
 
   @IsOptional()
   @IsString()
-  @IsLength(1, 100, {
-    message: 'Last name must be between 1 and 100 characters',
-  })
+  @MinLength(1)
+  @MaxLength(100)
   lastName?: string;
 
   @IsOptional()
   @IsString()
-  @IsLength(2, 100, { message: 'Country must be between 2 and 100 characters' })
+  @MinLength(2)
+  @MaxLength(100)
   country?: string;
 
   @IsOptional()
   @IsString()
-  @IsLength(0, 500, { message: 'Bio must be at most 500 characters' })
+  @MaxLength(500)
   bio?: string;
 
   @IsOptional()
   @IsString()
   @Matches(
     /^(https?:\/\/.*\.(?:png|jpg|jpeg|gif|webp))|^data:image\/(png|jpeg|gif|webp);base64,/i,
-    {
-      message: 'Avatar must be a valid URL or base64 encoded image',
-    },
+    { message: 'Avatar must be a valid URL or base64 encoded image' },
   )
   avatar?: string;
 
   @IsOptional()
   @IsString()
-  @Matches(/^G[A-Z0-9]{5,}$/, {
-    message: 'Invalid Stellar wallet address format',
-  })
+  @Matches(/^G[A-Z0-9]{5,}$/, { message: 'Invalid Stellar wallet address format' })
   walletAddress?: string;
 }

--- a/src/modules/users/email.service.ts
+++ b/src/modules/users/email.service.ts
@@ -4,14 +4,16 @@ import { Injectable, Logger } from '@nestjs/common';
 export class EmailService {
   private readonly logger = new Logger(EmailService.name);
 
-  async sendPasswordChangeConfirmation(
-    email: string,
-    userId: string,
-  ): Promise<void> {
-    // TODO: Implement actual email sending with a mailer (e.g., SendGrid, AWS SES, SMTP)
-    // For now, log the action
-    this.logger.log(
-      `Password change confirmation email would be sent to ${email} (user: ${userId})`,
-    );
+  async sendPasswordChangeConfirmation(email: string, userId: string): Promise<void> {
+    this.logger.log(`Password change confirmation email would be sent to ${email} (user: ${userId})`);
+  }
+
+  async sendPasswordResetEmail(email: string, token: string): Promise<void> {
+    // TODO: Implement actual email sending (SendGrid, AWS SES, SMTP)
+    this.logger.log(`Password reset email would be sent to ${email} with token: ${token}`);
+  }
+
+  async sendKycStatusEmail(email: string, status: string): Promise<void> {
+    this.logger.log(`KYC status update email (${status}) would be sent to ${email}`);
   }
 }

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -1,8 +1,12 @@
 import { Controller, Get, Post, Patch, Body } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { Public } from '../auth/decorators/public.decorator';
 import { ChangePasswordDto } from './dto/change-password.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
+import { SubmitKycDto } from './dto/submit-kyc.dto';
 
 interface JwtUser {
   id: string;
@@ -18,22 +22,31 @@ export class UsersController {
   }
 
   @Post('change-password')
-  async changePassword(
-    @CurrentUser() user: JwtUser,
-    @Body() changePasswordDto: ChangePasswordDto,
-  ) {
-    return this.usersService.changePassword(
-      user.id,
-      changePasswordDto.currentPassword,
-      changePasswordDto.newPassword,
-    );
+  async changePassword(@CurrentUser() user: JwtUser, @Body() dto: ChangePasswordDto) {
+    return this.usersService.changePassword(user.id, dto.currentPassword, dto.newPassword);
   }
 
   @Patch('profile')
-  async updateProfile(
-    @CurrentUser() user: JwtUser,
-    @Body() updateUserDto: UpdateUserDto,
-  ) {
-    return this.usersService.updateProfile(user.id, updateUserDto);
+  async updateProfile(@CurrentUser() user: JwtUser, @Body() dto: UpdateUserDto) {
+    return this.usersService.updateProfile(user.id, dto);
+  }
+
+  // Issue #141
+  @Public()
+  @Post('forgot-password')
+  async forgotPassword(@Body() dto: ForgotPasswordDto) {
+    return this.usersService.forgotPassword(dto.email);
+  }
+
+  @Public()
+  @Post('reset-password')
+  async resetPassword(@Body() dto: ResetPasswordDto) {
+    return this.usersService.resetPassword(dto.token, dto.newPassword);
+  }
+
+  // Issue #142
+  @Post('kyc/submit')
+  async submitKyc(@CurrentUser() user: JwtUser, @Body() dto: SubmitKycDto) {
+    return this.usersService.submitKyc(user.id, dto.documentUrl);
   }
 }

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -5,8 +5,10 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../../database/prisma.service';
 import * as bcrypt from 'bcryptjs';
+import * as crypto from 'crypto';
 import { EmailService } from './email.service';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { KycStatus } from '../../../generated/prisma';
 
 export interface UserProfileResponse {
   id: string;
@@ -213,6 +215,74 @@ export class UsersService {
       updatedAt,
       profileCompletion,
     };
+  }
+
+  // ── Issue #141: Forgot / Reset Password ──────────────────────────────────
+
+  async forgotPassword(email: string): Promise<{ message: string }> {
+    // Always return success to avoid user enumeration
+    const user = await this.prisma.user.findUnique({ where: { email } });
+    if (user) {
+      const token = crypto.randomBytes(32).toString('hex');
+      const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+
+      await this.prisma.emailToken.deleteMany({
+        where: { userId: user.id, type: 'PASSWORD_RESET' },
+      });
+
+      await this.prisma.emailToken.create({
+        data: { token, userId: user.id, type: 'PASSWORD_RESET', expiresAt },
+      });
+
+      await this.emailService.sendPasswordResetEmail(email, token);
+    }
+    return { message: 'If that email is registered, a reset link has been sent.' };
+  }
+
+  async resetPassword(token: string, newPassword: string): Promise<{ message: string }> {
+    const emailToken = await this.prisma.emailToken.findUnique({
+      where: { token },
+      include: { user: true },
+    });
+
+    if (!emailToken || emailToken.type !== 'PASSWORD_RESET') {
+      throw new BadRequestException('Invalid or expired reset token');
+    }
+    if (emailToken.expiresAt < new Date()) {
+      await this.prisma.emailToken.delete({ where: { id: emailToken.id } });
+      throw new BadRequestException('Reset token has expired');
+    }
+
+    const hashed = await bcrypt.hash(newPassword, 10);
+    await this.prisma.$transaction([
+      this.prisma.user.update({ where: { id: emailToken.userId }, data: { password: hashed } }),
+      this.prisma.emailToken.delete({ where: { id: emailToken.id } }),
+      this.prisma.refreshToken.deleteMany({ where: { userId: emailToken.userId } }),
+    ]);
+
+    return { message: 'Password reset successfully' };
+  }
+
+  // ── Issue #142: KYC Submit ────────────────────────────────────────────────
+
+  async submitKyc(userId: string, documentUrl: string): Promise<{ message: string }> {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+
+    if (user.kycStatus === KycStatus.APPROVED) {
+      throw new BadRequestException('KYC already approved');
+    }
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        kycStatus: KycStatus.PENDING,
+        kycDocumentUrl: documentUrl,
+        kycSubmittedAt: new Date(),
+      },
+    });
+
+    return { message: 'KYC submitted successfully' };
   }
 
   private calculateProfileCompletion(user: any): number {


### PR DESCRIPTION
## Summary

This PR resolves all 4 issues assigned to @nanaf6203-bit.

---

### Closes #141 — Forgot Password Flow
- `POST /users/forgot-password` — generates a secure one-time token (1h expiry), sends reset email, always returns success (prevents user enumeration)
- `POST /users/reset-password` — validates token, updates password, invalidates token + all refresh tokens

### Closes #142 — User KYC Status Management
- Added `KycStatus` enum: `NONE | PENDING | APPROVED | REJECTED`
- Added KYC fields to `User` model: `kycStatus`, `kycDocumentUrl`, `kycSubmittedAt`, `kycVerifiedAt`
- `POST /users/kyc/submit` — authenticated users submit KYC document URL
- `PATCH /admin/users/:id/kyc` — admins approve/reject KYC with email notification

### Closes #143 — Admin User Management Endpoints
- `GET /admin/users` — paginated list with `role` and `kycStatus` filters
- `GET /admin/users/:id` — get single user
- `PATCH /admin/users/:id/role` — update user role
- `DELETE /admin/users/:id` — soft delete (sets `deletedAt` + status `DELETED`)
- All routes protected with `@Roles(UserRole.ADMIN)`

### Closes #144 — Projects Module & Prisma Schema
- Added `ProjectStatus` enum: `PENDING | APPROVED | REJECTED | ACTIVE | COMPLETED`
- Added `ProjectCategory` enum: `HEALTH | EDUCATION | DISASTER_RELIEF | ENVIRONMENT | POVERTY | HUMAN_RIGHTS | COMMUNITY | OTHER`
- `Project` model with all fields, foreign key to `users`, indexes on `creatorId` and `status`
- `POST /projects`, `GET /projects`, `GET /projects/:id` endpoints

---

### Files Changed
- `prisma/schema.prisma` — KycStatus, ProjectStatus, ProjectCategory enums; KYC fields on User; Project model
- `src/modules/users/` — forgot/reset password + KYC submit endpoints
- `src/modules/admin/` — new admin module with user management + KYC admin endpoints
- `src/modules/projects/` — new projects module with schema and CRUD
- `src/app.module.ts` — registered AdminModule and ProjectsModule