### PR TITLE
feat: add /health and /health/ready endpoints with DB, Redis, Horizon checks

### DIFF
--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -2,24 +2,42 @@ import { Controller, Get } from '@nestjs/common';
 import {
   HealthCheck,
   HealthCheckService,
-  MemoryHealthIndicator,
+  HttpHealthIndicator,
+  PrismaHealthIndicator,
 } from '@nestjs/terminus';
 import { RedisHealthIndicator } from './redis.health';
+import { PrismaService } from '../prisma/prisma.service';
+import { ConfigService } from '@nestjs/config';
 
 @Controller('health')
 export class HealthController {
   constructor(
-    private health: HealthCheckService,
-    private memory: MemoryHealthIndicator,
-    private redisHealth: RedisHealthIndicator,
+    private readonly health: HealthCheckService,
+    private readonly http: HttpHealthIndicator,
+    private readonly prismaHealth: PrismaHealthIndicator,
+    private readonly prisma: PrismaService,
+    private readonly redisHealth: RedisHealthIndicator,
+    private readonly config: ConfigService,
   ) {}
 
+  /** Liveness probe — returns 200 when the process is running. */
   @Get()
   @HealthCheck()
   check() {
+    const horizonUrl =
+      this.config.get<string>('STELLAR_HORIZON_URL') ??
+      'https://horizon-testnet.stellar.org';
     return this.health.check([
-      () => this.memory.checkHeap('memory_heap', 150 * 1024 * 1024),
+      () => this.prismaHealth.pingCheck('database', this.prisma),
       () => this.redisHealth.isHealthy('redis'),
+      () => this.http.pingCheck('stellar_horizon', horizonUrl),
     ]);
+  }
+
+  /** Readiness probe — confirms all dependencies are reachable. */
+  @Get('ready')
+  @HealthCheck()
+  ready() {
+    return this.check();
   }
 }


### PR DESCRIPTION
## Summary
Updates \src/health/health.controller.ts\ to add:
- \GET /health\ — liveness probe checking PostgreSQL (Prisma), Redis, and Stellar Horizon reachability
- \GET /health/ready\ — readiness probe (same checks)

closes #216