### PR TITLE
feat: implement GET /auth/challenge wallet challenge generation endpoint

### DIFF
--- a/src/auth/auth-challenge.controller.ts
+++ b/src/auth/auth-challenge.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Query, BadRequestException } from '@nestjs/common';
+import { randomBytes } from 'crypto';
+import { StrKey } from '@stellar/stellar-sdk';
+
+interface ChallengeResponse {
+  challenge: string;
+}
+
+/**
+ * GET /auth/challenge?walletAddress=G...
+ *
+ * Returns a one-time challenge string for the client to sign with their
+ * Stellar keypair. Format: `stellaraid:login:<nonce>:<timestamp>`
+ */
+@Controller('auth')
+export class AuthChallengeController {
+  @Get('challenge')
+  getChallenge(
+    @Query('walletAddress') walletAddress: string,
+  ): ChallengeResponse {
+    if (!walletAddress || !StrKey.isValidEd25519PublicKey(walletAddress)) {
+      throw new BadRequestException('Invalid Stellar wallet address');
+    }
+
+    const nonce = randomBytes(16).toString('hex');
+    const timestamp = Math.floor(Date.now() / 1000);
+    const challenge = `stellaraid:login:${nonce}:${timestamp}`;
+
+    return { challenge };
+  }
+}


### PR DESCRIPTION
Closes #217

---

## Summary
Adds \src/auth/auth-challenge.controller.ts\ implementing \GET /auth/challenge?walletAddress=G...\.
- Validates the address with \stellar-sdk\ \StrKey.isValidEd25519PublicKey\
- Returns \{ challenge: \