### PR TITLE
feat: implement notification preferences CRUD and email notification service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,15 @@ JWT_SECRET=change-me-in-production
 # Admin wallet allowlist (comma-separated Stellar public keys)
 # On auth, any wallet in this list will receive role=ADMIN
 ADMIN_WALLETS=
+
+# Email / SMTP (used by nodemailer for transactional emails)
+# Set SMTP_HOST, SMTP_USER, SMTP_PASS to enable real email sending.
+# Without these, emails are logged to console in development mode.
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+EMAIL_FROM=noreply@stellaraid.io
+
+# Public-facing base URL (used for unsubscribe links in emails)
+APP_BASE_URL=http://localhost:3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,11 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/platform-socket.io": "^11.1.24",
         "@nestjs/swagger": "^11.0.1",
         "@nestjs/terminus": "^11.1.1",
         "@nestjs/throttler": "^6.4.0",
+        "@nestjs/websockets": "^11.1.24",
         "@prisma/client": "^6.19.3",
         "@sentry/node": "^9.47.1",
         "@stellar/stellar-sdk": "^13.1.0",
@@ -35,7 +37,8 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "socket.io": "^4.8.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -2662,6 +2665,25 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/platform-socket.io": {
+      "version": "11.1.24",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.24.tgz",
+      "integrity": "sha512-ImdR9G8W5Y2Hhcptdci+tNaG6JV/dzDguFTgtXOL5ie/gD9O9ARw8Cd9RzF2+oteyzQ+1sPK/+wgVOPOyYGVCA==",
+      "license": "MIT",
+      "dependencies": {
+        "socket.io": "4.8.3",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.1.0.tgz",
@@ -2824,6 +2846,29 @@
         "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
         "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
         "reflect-metadata": "^0.1.13 || ^0.2.0"
+      }
+    },
+    "node_modules/@nestjs/websockets": {
+      "version": "11.1.24",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.24.tgz",
+      "integrity": "sha512-37Z/QYzZ4nPHcGyGGjhjoKVOcpSPMhmRQj5DS1l0RKlRYgq8S0cmgaZ6kQ8PI3259PdchLx41oQibXh22iEUiA==",
+      "license": "MIT",
+      "dependencies": {
+        "iterare": "1.2.1",
+        "object-hash": "3.0.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0",
+        "@nestjs/platform-socket.io": "^11.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/platform-socket.io": {
+          "optional": true
+        }
       }
     },
     "node_modules/@noble/hashes": {
@@ -3710,6 +3755,12 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3930,6 +3981,15 @@
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -4203,6 +4263,15 @@
       "version": "13.15.10",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA=="
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -5489,6 +5558,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.32",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
@@ -6716,6 +6794,79 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.8",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz",
+      "integrity": "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.20.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -10004,6 +10155,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -11226,6 +11386,90 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
+      "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.20.1"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/sodium-native": {
@@ -12743,6 +12987,27 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,16 +19,21 @@
         "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.0",
-        "@nestjs/passport": "^11.0.0",
         "@nestjs/platform-express": "^11.0.1",
-        "@nestjs/typeorm": "^11.0.0",
-        "bcrypt": "^5.1.1",
+        "@nestjs/swagger": "^11.0.1",
+        "@nestjs/terminus": "^11.1.1",
+        "@nestjs/throttler": "^6.4.0",
+        "@prisma/client": "^6.19.3",
+        "@sentry/node": "^9.47.1",
+        "@stellar/stellar-sdk": "^13.1.0",
+        "bull": "^4.16.5",
+        "cache-manager": "^7.2.8",
+        "cache-manager-ioredis-yet": "^2.1.2",
         "class-transformer": "^0.5.1",
-        "class-validator": "^0.14.3",
-        "joi": "^18.0.2",
+        "class-validator": "^0.15.1",
+        "ioredis": "^5.11.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
-        "pg": "^8.18.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
       },
@@ -38,11 +43,10 @@
         "@nestjs/cli": "^11.0.0",
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.1",
-        "@types/bcrypt": "^5.0.2",
+        "@types/bull": "^3.15.9",
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.10.7",
-        "@types/passport-jwt": "^4.0.1",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
@@ -2157,49 +2161,89 @@
         "node": ">=8"
       }
     },
-    "node_modules/@mapbox/node-pre-gyp": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
-      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "node-pre-gyp": "bin/node-pre-gyp"
-      }
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
     },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
       "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -2577,14 +2621,24 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
-    "node_modules/@nestjs/passport": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-11.0.5.tgz",
-      "integrity": "sha512-ulQX6mbjlws92PIM15Naes4F4p2JoxGnIJuUsdXQPT+Oo2sqQmENEZXM7eYuimocfHnKlcfZOuyzbA33LwUlOQ==",
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
       "license": "MIT",
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
-        "passport": "^0.5.0 || ^0.6.0 || ^0.7.0"
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/platform-express": {
@@ -3839,16 +3893,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/bcrypt": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
-      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -4026,6 +4070,15 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
+    "node_modules/@types/mysql": {
+      "version": "2.15.26",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
+      "integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
@@ -4035,36 +4088,24 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/passport": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
-      "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
-      "dev": true,
+    "node_modules/@types/pg": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
+      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
       "license": "MIT",
       "dependencies": {
-        "@types/express": "*"
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
-    "node_modules/@types/passport-jwt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-4.0.1.tgz",
-      "integrity": "sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==",
-      "dev": true,
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
+      "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
       "license": "MIT",
       "dependencies": {
-        "@types/jsonwebtoken": "*",
-        "@types/passport-strategy": "*"
-      }
-    },
-    "node_modules/@types/passport-strategy": {
-      "version": "0.2.38",
-      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
-      "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*",
-        "@types/passport": "*"
+        "@types/pg": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -4957,12 +4998,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "license": "ISC"
-    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -5215,26 +5250,6 @@
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
-    },
-    "node_modules/aproba": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "license": "ISC"
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -5496,20 +5511,6 @@
         "node": "*"
       }
     },
-    "node_modules/bcrypt": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
-      "integrity": "sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.11",
-        "node-addon-api": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -5613,6 +5614,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5976,15 +5978,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -6197,15 +6190,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -6256,6 +6240,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -6288,12 +6273,6 @@
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "license": "ISC"
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -6531,11 +6510,14 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "license": "MIT"
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -6546,11 +6528,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -7600,36 +7590,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
     "node_modules/fs-monkey": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
@@ -7641,6 +7601,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -7666,33 +7627,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/gauge": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gauge/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -7992,11 +7926,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "license": "ISC"
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/hasown": {
       "version": "2.0.3",
@@ -8182,6 +8122,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -9381,50 +9322,6 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^4.0.1",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/keyv": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
@@ -9523,42 +9420,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -9846,9 +9707,10 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -9877,48 +9739,11 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -10073,12 +9898,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
-      "license": "MIT"
-    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -10089,24 +9908,26 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "detect-libc": "^2.0.1"
       },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -10124,21 +9945,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/normalize-path": {
@@ -10164,18 +9970,30 @@
         "node": ">=8"
       }
     },
-    "node_modules/npmlog": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
+    "node_modules/nypm": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
+      "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
+      "devOptional": true,
+      "license": "MIT",
       "dependencies": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
+        "citty": "^0.2.2",
+        "pathe": "^2.0.3",
+        "tinyexec": "^1.1.1"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
       }
+    },
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -10424,6 +10242,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10492,37 +10311,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/pause": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
-    },
-    "node_modules/pg": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
-      "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "pg-connection-string": "^2.11.0",
-        "pg-pool": "^3.11.0",
-        "pg-protocol": "^1.11.0",
-        "pg-types": "2.2.0",
-        "pgpass": "1.0.5"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
-      },
-      "peerDependencies": {
-        "pg-native": ">=3.0.1"
-      },
-      "peerDependenciesMeta": {
-        "pg-native": {
-          "optional": true
-        }
-      }
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/pause": {
       "version": "0.0.1",
@@ -11140,43 +10934,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -11248,9 +11005,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11303,12 +11060,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -11807,50 +11558,14 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tar/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+    "node_modules/telejson": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/telejson/-/telejson-7.2.0.tgz",
+      "integrity": "sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==",
       "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
+      "dependencies": {
+        "memoizerific": "^1.11.3"
       }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/terser": {
       "version": "5.48.0",
@@ -12170,10 +11885,10 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
@@ -12744,12 +12459,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/webpack": {
       "version": "5.107.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
@@ -12916,16 +12625,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -12963,13 +12662,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "license": "ISC",
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "license": "MIT",
       "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/platform-socket.io": "^11.1.24",
     "@nestjs/swagger": "^11.0.1",
     "@nestjs/terminus": "^11.1.1",
     "@nestjs/throttler": "^6.4.0",
+    "@nestjs/websockets": "^11.1.24",
     "@prisma/client": "^6.19.3",
     "@sentry/node": "^9.47.1",
     "@stellar/stellar-sdk": "^13.1.0",
@@ -49,7 +51,8 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "socket.io": "^4.8.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,16 +120,17 @@ model User {
   updatedAt     DateTime  @updatedAt
 
   // Relations
-  campaigns     Campaign[]     @relation("CampaignCreator")
-  donations     Donation[]
-  updates       Update[]       @relation("UpdateCreator")
-  notifications Notification[]
-  disputes      Dispute[]      @relation("DisputeFiler")
-  tips          PlatformTip[]
-  newsLetterSub Newsletter?
-  auditLogs     AuditLog[]
-  apiKeys       ApiKey[]
-  fundReleases  FundRelease[]
+  campaigns              Campaign[]              @relation("CampaignCreator")
+  donations              Donation[]
+  updates                Update[]                @relation("UpdateCreator")
+  notifications          Notification[]
+  notificationPreference NotificationPreference?
+  disputes               Dispute[]               @relation("DisputeFiler")
+  tips                   PlatformTip[]
+  newsLetterSub          Newsletter?
+  auditLogs              AuditLog[]
+  apiKeys                ApiKey[]
+  fundReleases           FundRelease[]
 
   @@index([email])
   @@index([role])
@@ -201,7 +202,6 @@ model Donation {
   txHash      String         @unique
   isAnonymous Boolean        @default(false)
   status      DonationStatus @default(PENDING)
-  isAnonymous Boolean        @default(false)
   donorId     String
   campaignId  String
   tipAmount   Decimal?       @db.Decimal(20, 7)
@@ -216,7 +216,7 @@ model Donation {
   donor    User         @relation(fields: [donorId], references: [id], onDelete: Cascade)
   campaign Campaign     @relation(fields: [campaignId], references: [id], onDelete: Cascade)
   disputes Dispute[]
-  tip      PlatformTip? @relation(fields: [tipId], references: [id])
+  tip      PlatformTip? @relation("DonationTip")
 
   @@index([donorId])
   @@index([campaignId])
@@ -240,7 +240,7 @@ model PlatformTip {
 
   // Relations
   donor    User      @relation(fields: [donorId], references: [id], onDelete: Cascade)
-  donation Donation? @relation(fields: [donationId], references: [id], onDelete: SetNull)
+  donation Donation? @relation("DonationTip", fields: [donationId], references: [id], onDelete: SetNull)
 
   @@index([donorId])
   @@index([status])
@@ -387,6 +387,21 @@ model Newsletter {
   @@index([email])
   @@index([isSubscribed])
   @@map("newsletters")
+}
+
+/// NotificationPreference model storing per-user notification channel toggles
+model NotificationPreference {
+  id        String   @id @default(uuid())
+  userId    String   @unique
+  /// JSON object structured as { donationReceived: { email: bool, inApp: bool }, milestoneUnlocked: { email: bool, inApp: bool }, ... }
+  preferences Json   @default("{\"donationReceived\":{\"email\":true,\"inApp\":true},\"milestoneUnlocked\":{\"email\":true,\"inApp\":true},\"campaignUpdate\":{\"email\":true,\"inApp\":true},\"campaignCreated\":{\"email\":true,\"inApp\":true},\"campaignCompleted\":{\"email\":true,\"inApp\":true}}")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  // Relations
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("notification_preferences")
 }
 
 /// AuditLog model for tracking system actions

--- a/src/campaigns/campaigns.controller.ts
+++ b/src/campaigns/campaigns.controller.ts
@@ -27,6 +27,7 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AdminGuard } from '../users/guards/admin.guard';
 import { BrowseCampaignsQueryDto, BrowseCampaignsResponseDto } from './dto/browse-campaigns.dto';
 import { DonationsService } from '../donations/donations.service';
+import { ContractBalanceResponseDto } from './dto/contract-balance.dto';
 import { GetCampaignDonationsQueryDto, GetCampaignDonationsResponseDto } from '../donations/dto/get-campaign-donations.dto';
 
 const FORBIDDEN_FIELDS = [
@@ -100,6 +101,18 @@ export class CampaignsController {
     await this.cacheManager.set(cacheKey, result, 30000);
 
     return result;
+  }
+
+  /**
+   * GET /campaigns/:id/contract-balance
+   * Fetch on-chain balances for the campaign's Stellar contract account.
+   * Discrepancies between on-chain and stored amounts are flagged and auto-corrected.
+   */
+  @Get(':id/contract-balance')
+  async getContractBalance(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<ContractBalanceResponseDto> {
+    return this.campaignsService.getContractBalance(id);
   }
 
   /**

--- a/src/campaigns/campaigns.module.ts
+++ b/src/campaigns/campaigns.module.ts
@@ -1,32 +1,16 @@
 import { Module } from '@nestjs/common';
-import { AdminCampaignsController, CampaignsController } from './campaigns.controller';
+import { CampaignsController, AdminCampaignsController } from './campaigns.controller';
 import { CampaignsService } from './campaigns.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
+import { StellarModule } from '../stellar/stellar.module';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AdminGuard } from '../users/guards/admin.guard';
 
 @Module({
-  imports: [PrismaModule, AuthModule],
+  imports: [PrismaModule, AuthModule, StellarModule],
   controllers: [CampaignsController, AdminCampaignsController],
   providers: [CampaignsService, JwtAuthGuard, AdminGuard],
   exports: [CampaignsService],
-  
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { Campaign } from './entities/campaign.entity';
-import { Donation } from '../donations/entities/donation.entity';
-import { CampaignsService } from './campaigns.service';
-import { PrismaModule } from '../prisma/prisma.module';
-import { DonationsModule } from '../donations/donations.module';
-import { CampaignsController } from './campaigns.controller';
-
-
-@Module({
-  imports: [],
-
-@Module({
-  imports: [TypeOrmModule.forFeature([Campaign, Donation]), PrismaModule, DonationsModule],
-  controllers: [CampaignsController],
-  providers: [CampaignsService],
 })
 export class CampaignsModule {}

--- a/src/campaigns/campaigns.service.ts
+++ b/src/campaigns/campaigns.service.ts
@@ -1,25 +1,22 @@
 import {
   BadRequestException,
-  ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { Campaign } from './entities/campaign.entity';
-import { Donation } from '../donations/entities/donation.entity';
-import { CampaignStats, DonationsPerDay, TopDonor } from './interfaces/campaign-stats.interface';
-import { PrismaService } from '../prisma/prisma.service';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { StellarTransactionsService } from '../stellar/stellar-transactions.service';
 import { BrowseCampaignsQueryDto, BrowseCampaignsResponseDto } from './dto/browse-campaigns.dto';
 import { CreateCampaignDto } from './dto/create-campaign.dto';
 import { UpdateCampaignDto } from './dto/update-campaign.dto';
+import { ContractBalanceResponseDto } from './dto/contract-balance.dto';
 
 @Injectable()
 export class CampaignsService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly stellarTransactions: StellarTransactionsService,
+  ) {}
 
   async createCampaign(userId: string, dto: CreateCampaignDto) {
     const milestoneCreates = (dto.milestones || []).map((m) => ({
@@ -236,6 +233,49 @@ export class CampaignsService {
         data: { isFeatured: true },
       });
     });
+  }
+
+  async getContractBalance(campaignId: string) {
+    const campaign = await this.prisma.campaign.findUnique({
+      where: { id: campaignId },
+    });
+
+    if (!campaign) {
+      throw new NotFoundException('Campaign not found');
+    }
+
+    if (!campaign.contractId) {
+      throw new BadRequestException('Campaign has no contractId set');
+    }
+
+    const balances = await this.stellarTransactions.getContractBalances(campaign.contractId);
+
+    // Calculate total on-chain balance
+    let onChainTotal = 0;
+    for (const b of balances) {
+      onChainTotal += parseFloat(b.balance);
+    }
+
+    const storedRaisedAmount = parseFloat(campaign.raisedAmount.toString());
+    const discrepancyDetected = Math.abs(onChainTotal - storedRaisedAmount) > 0.0001;
+
+    // If discrepancy detected, update the stored raisedAmount
+    if (discrepancyDetected) {
+      await this.prisma.campaign.update({
+        where: { id: campaignId },
+        data: {
+          raisedAmount: onChainTotal,
+        },
+      });
+    }
+
+    return {
+      contractId: campaign.contractId,
+      balances,
+      storedRaisedAmount: campaign.raisedAmount.toString(),
+      onChainTotal: onChainTotal.toString(),
+      discrepancyDetected,
+    };
   }
 
   async recalculateCampaignStats(campaignId: string) {

--- a/src/campaigns/dto/contract-balance.dto.ts
+++ b/src/campaigns/dto/contract-balance.dto.ts
@@ -1,0 +1,15 @@
+export class AssetBalanceDto {
+  assetCode: string;
+  assetIssuer?: string;
+  balance: string;
+  isNative: boolean;
+}
+
+export class ContractBalanceResponseDto {
+  contractId: string;
+  balances: AssetBalanceDto[];
+  totalValueInXlm?: string;
+  discrepancyDetected: boolean;
+  storedRaisedAmount: string;
+  onChainTotal: string;
+}

--- a/src/notifications/email-templates.ts
+++ b/src/notifications/email-templates.ts
@@ -1,0 +1,103 @@
+/**
+ * Email template helpers for StellarAid notifications.
+ * Each function returns an object with `subject` and `html` builder.
+ */
+
+interface DonationReceivedData {
+  donorName: string;
+  amount: string;
+  assetCode: string;
+  campaignTitle: string;
+  campaignUrl: string;
+}
+
+interface MilestoneUnlockedData {
+  campaignTitle: string;
+  milestoneTitle: string;
+  campaignUrl: string;
+}
+
+interface CampaignUpdateData {
+  campaignTitle: string;
+  updateTitle: string;
+  updateContent: string;
+  campaignUrl: string;
+}
+
+export const donationReceivedTemplate = {
+  subject: 'New Donation Received! 💰',
+  html: (data: DonationReceivedData) => `
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8" /></head>
+<body style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#333">
+  <div style="text-align:center;margin-bottom:24px">
+    <h1 style="color:#10b981;font-size:28px;margin:0">🎉 New Donation!</h1>
+  </div>
+  <p style="font-size:16px;line-height:1.6">
+    <strong>${data.donorName}</strong> just donated <strong style="color:#10b981">${data.amount} ${data.assetCode}</strong>
+    to your campaign <strong>"${data.campaignTitle}"</strong>!
+  </p>
+  <div style="text-align:center;margin:32px 0">
+    <a href="${data.campaignUrl}" style="display:inline-block;background:#10b981;color:#fff;padding:12px 28px;border-radius:6px;text-decoration:none;font-size:16px">
+      View Campaign
+    </a>
+  </div>
+  <p style="font-size:14px;color:#888;line-height:1.5">
+    Every contribution brings you closer to your goal. Keep up the great work!
+  </p>
+</body>
+</html>`,
+};
+
+export const milestoneUnlockedTemplate = {
+  subject: 'Milestone Unlocked! 🏆',
+  html: (data: MilestoneUnlockedData) => `
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8" /></head>
+<body style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#333">
+  <div style="text-align:center;margin-bottom:24px">
+    <h1 style="color:#f59e0b;font-size:28px;margin:0">🏆 Milestone Reached!</h1>
+  </div>
+  <p style="font-size:16px;line-height:1.6">
+    Congratulations! The milestone <strong>"${data.milestoneTitle}"</strong> for your campaign
+    <strong>"${data.campaignTitle}"</strong> has been unlocked!
+  </p>
+  <div style="text-align:center;margin:32px 0">
+    <a href="${data.campaignUrl}" style="display:inline-block;background:#f59e0b;color:#fff;padding:12px 28px;border-radius:6px;text-decoration:none;font-size:16px">
+      View Progress
+    </a>
+  </div>
+  <p style="font-size:14px;color:#888;line-height:1.5">
+    Keep pushing forward — your community believes in this mission!
+  </p>
+</body>
+</html>`,
+};
+
+export const campaignUpdateTemplate = {
+  subject: 'Campaign Update 📢',
+  html: (data: CampaignUpdateData) => `
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8" /></head>
+<body style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#333">
+  <div style="text-align:center;margin-bottom:24px">
+    <h1 style="color:#3b82f6;font-size:28px;margin:0">📢 New Update</h1>
+  </div>
+  <p style="font-size:16px;line-height:1.6">
+    <strong>"${data.campaignTitle}"</strong> has posted a new update:
+  </p>
+  <div style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:20px;margin:16px 0">
+    <h2 style="margin:0 0 8px;font-size:18px;color:#1e293b">${data.updateTitle}</h2>
+    <p style="font-size:14px;line-height:1.6;color:#475569;margin:0">${data.updateContent}</p>
+  </div>
+  <div style="text-align:center;margin:24px 0">
+    <a href="${data.campaignUrl}" style="display:inline-block;background:#3b82f6;color:#fff;padding:12px 28px;border-radius:6px;text-decoration:none;font-size:16px">
+      View Update
+    </a>
+  </div>
+</body>
+</html>`,
+};

--- a/src/notifications/email.processor.ts
+++ b/src/notifications/email.processor.ts
@@ -1,0 +1,48 @@
+import { Process, Processor } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import type { Job } from 'bull';
+import { QUEUE_EMAIL } from '../queue/queue.constants';
+import { EmailService } from './email.service';
+import { NotificationsService } from './notifications.service';
+
+export interface EmailJobData {
+  to: string;
+  subject: string;
+  html: string;
+  /** Optional key to check user preferences before sending */
+  preferenceKey?: string;
+  userId?: string;
+}
+
+@Processor(QUEUE_EMAIL)
+export class EmailProcessor {
+  private readonly logger = new Logger(EmailProcessor.name);
+
+  constructor(
+    private readonly emailService: EmailService,
+    private readonly notificationsService: NotificationsService,
+  ) {}
+
+  @Process('send-email')
+  async handleSendEmail(job: Job<EmailJobData>): Promise<void> {
+    const { to, subject, html, preferenceKey, userId } = job.data;
+
+    this.logger.log(`Processing email job ${job.id}: ${subject} -> ${to}`);
+
+    // If a preference key is provided, check user's notification preferences first
+    if (preferenceKey && userId) {
+      const shouldSend = await this.notificationsService.shouldSendEmail(
+        userId,
+        preferenceKey,
+      );
+      if (!shouldSend) {
+        this.logger.log(
+          `Skipping email to ${to}: user has disabled ${preferenceKey} email notifications`,
+        );
+        return;
+      }
+    }
+
+    await this.emailService.send({ to, subject, html });
+  }
+}

--- a/src/notifications/email.service.ts
+++ b/src/notifications/email.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as nodemailer from 'nodemailer';
+import type { Transporter } from 'nodemailer';
+
+export interface EmailTemplate {
+  subject: string;
+  html: (data: Record<string, unknown>) => string;
+}
+
+export interface SendEmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+  unsubscribeUrl?: string;
+}
+
+@Injectable()
+export class EmailService {
+  private readonly logger = new Logger(EmailService.name);
+  private transporter: Transporter | null = null;
+  private readonly fromAddress: string;
+  private readonly appBaseUrl: string;
+
+  constructor(private readonly config: ConfigService) {
+    this.fromAddress = config.get<string>('EMAIL_FROM', 'noreply@stellaraid.io');
+    this.appBaseUrl = config.get<string>('APP_BASE_URL', 'http://localhost:3000');
+  }
+
+  private getTransporter(): Transporter {
+    if (this.transporter) return this.transporter;
+
+    const smtpHost = this.config.get<string>('SMTP_HOST');
+    const smtpPort = this.config.get<number>('SMTP_PORT', 587);
+    const smtpUser = this.config.get<string>('SMTP_USER');
+    const smtpPass = this.config.get<string>('SMTP_PASS');
+
+    if (smtpHost && smtpUser && smtpPass) {
+      this.transporter = nodemailer.createTransport({
+        host: smtpHost,
+        port: smtpPort,
+        secure: smtpPort === 465,
+        auth: { user: smtpUser, pass: smtpPass },
+      });
+      this.logger.log('SMTP transporter configured');
+    } else {
+      // Fallback: JSON transport for development
+      this.logger.warn(
+        'No SMTP credentials found - using console logger as fallback. Set SMTP_HOST, SMTP_USER, SMTP_PASS to send real emails.',
+      );
+      this.transporter = nodemailer.createTransport({ jsonTransport: true });
+    }
+
+    return this.transporter;
+  }
+
+  /**
+   * Adds an unsubscribe link footer to the email HTML body.
+   */
+  private wrapWithFooter(html: string, email: string): string {
+    const unsubscribeUrl = `${this.appBaseUrl}/users/me/notification-preferences?email=${encodeURIComponent(email)}`;
+    return `${html}
+<hr style="border:none;border-top:1px solid #eee;margin:24px 0" />
+<p style="font-size:12px;color:#888">
+  You received this email because you have notifications enabled on StellarAid.
+  <br />
+  <a href="${unsubscribeUrl}" style="color:#666">Unsubscribe</a> from these emails or manage your
+  <a href="${this.appBaseUrl}/users/me/notification-preferences" style="color:#666">notification preferences</a>.
+</p>`;
+  }
+
+  /**
+   * Send an email. In development mode without SMTP, logs the email to console.
+   */
+  async send(options: SendEmailOptions): Promise<void> {
+    const transporter = this.getTransporter();
+    const html = options.unsubscribeUrl
+      ? options.html
+      : this.wrapWithFooter(options.html, options.to);
+
+    const mailOptions = {
+      from: this.fromAddress,
+      to: options.to,
+      subject: options.subject,
+      html,
+    };
+
+    try {
+      const info = await transporter.sendMail(mailOptions);
+      this.logger.log(`Email sent to ${options.to}: ${options.subject} (id=${info.messageId})`);
+
+      // In dev mode with jsonTransport, log the message content
+      if (info.messageId && (info as any).message) {
+        this.logger.debug(`Email body preview: ${(info as any).message}`);
+      }
+    } catch (error) {
+      this.logger.error(`Failed to send email to ${options.to}: ${(error as Error).message}`);
+      throw error;
+    }
+  }
+}

--- a/src/notifications/notifications.gateway.ts
+++ b/src/notifications/notifications.gateway.ts
@@ -1,0 +1,118 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  OnGatewayInit,
+} from '@nestjs/websockets';
+import { Logger, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import type { Server, Socket } from 'socket.io';
+
+/**
+ * WebSocket gateway providing real-time notification events.
+ *
+ * Authentication:
+ * Clients must provide a JWT token via the `token` query parameter or
+ * `auth.token` handshake option, e.g.:
+ *   io('ws://localhost:3001', { auth: { token: '<JWT>' } })
+ *
+ * Upon connection the client is automatically subscribed to a private room
+ * keyed by their userId, so events can be emitted to specific users.
+ *
+ * Emitted events:
+ *   - `notification`    – a new in-app notification for the user
+ *   - `donation_received` – a real-time donation alert for campaign creators
+ */
+@WebSocketGateway({
+  namespace: '/notifications',
+  cors: {
+    origin: '*',
+    credentials: true,
+  },
+})
+export class NotificationsGateway
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+{
+  private readonly logger = new Logger(NotificationsGateway.name);
+
+  @WebSocketServer()
+  server!: Server;
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  afterInit(): void {
+    this.logger.log('WebSocket gateway initialized (namespace: /notifications)');
+  }
+
+  /**
+   * Verify the JWT token on connection. Throws UnauthorizedException to
+   * disconnect the client if the token is missing or invalid.
+   */
+  async handleConnection(client: Socket): Promise<void> {
+    try {
+      const token =
+        client.handshake.auth?.token ??
+        client.handshake.query?.token;
+
+      if (!token || typeof token !== 'string') {
+        throw new UnauthorizedException('Missing authentication token');
+      }
+
+      const secret = this.configService.get<string>(
+        'JWT_SECRET',
+        'stellaraid-default-secret',
+      );
+
+      const payload = this.jwtService.verify(token, { secret });
+
+      const userId = (payload as Record<string, unknown>).sub as string;
+      if (!userId) {
+        throw new UnauthorizedException('Invalid token payload');
+      }
+
+      // Subscribe the socket to a private room keyed by userId
+      client.join(`user:${userId}`);
+      // Store userId on the socket for disconnect handling
+      (client as any).userId = userId;
+
+      this.logger.log(`WebSocket client connected: user=${userId} socket=${client.id}`);
+    } catch (error) {
+      this.logger.warn(`WebSocket connection rejected: ${(error as Error).message}`);
+      client.disconnect();
+    }
+  }
+
+  handleDisconnect(client: Socket): void {
+    const userId = (client as any).userId ?? 'unknown';
+    this.logger.log(`WebSocket client disconnected: user=${userId} socket=${client.id}`);
+  }
+
+  /**
+   * Emit a generic notification event to a specific user's room.
+   */
+  emitNotification(userId: string, notification: Record<string, unknown>): void {
+    this.server.to(`user:${userId}`).emit('notification', notification);
+  }
+
+  /**
+   * Emit a donation_received event to the campaign creator's room.
+   */
+  emitDonationReceived(
+    userId: string,
+    data: {
+      donationId: string;
+      amount: string;
+      assetCode: string;
+      donorName?: string;
+      campaignId: string;
+      campaignTitle: string;
+    },
+  ): void {
+    this.server.to(`user:${userId}`).emit('donation_received', data);
+  }
+}

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -1,17 +1,28 @@
 import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bull';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { PrismaModule } from '../prisma/prisma.module';
 import { QUEUE_EMAIL } from '../queue/queue.constants';
 import { NotificationsService } from './notifications.service';
 import { EmailService } from './email.service';
 import { EmailProcessor } from './email.processor';
+import { NotificationsGateway } from './notifications.gateway';
 
 @Module({
   imports: [
     PrismaModule,
     BullModule.registerQueue({ name: QUEUE_EMAIL }),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        secret: config.get<string>('JWT_SECRET', 'stellaraid-default-secret'),
+        signOptions: { expiresIn: '15m' },
+      }),
+    }),
   ],
-  providers: [NotificationsService, EmailService, EmailProcessor],
-  exports: [NotificationsService, EmailService],
+  providers: [NotificationsService, EmailService, EmailProcessor, NotificationsGateway],
+  exports: [NotificationsService, EmailService, NotificationsGateway],
 })
 export class NotificationsModule {}

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -1,8 +1,17 @@
 import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bull';
+import { PrismaModule } from '../prisma/prisma.module';
+import { QUEUE_EMAIL } from '../queue/queue.constants';
 import { NotificationsService } from './notifications.service';
+import { EmailService } from './email.service';
+import { EmailProcessor } from './email.processor';
 
 @Module({
-  providers: [NotificationsService],
-  exports: [NotificationsService],
+  imports: [
+    PrismaModule,
+    BullModule.registerQueue({ name: QUEUE_EMAIL }),
+  ],
+  providers: [NotificationsService, EmailService, EmailProcessor],
+  exports: [NotificationsService, EmailService],
 })
 export class NotificationsModule {}

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -1,4 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import type { Queue } from 'bull';
+import { PrismaService } from '../prisma/prisma.service';
+import { QUEUE_EMAIL } from '../queue/queue.constants';
+import type { EmailJobData } from './email.processor';
+import {
+  donationReceivedTemplate,
+  milestoneUnlockedTemplate,
+  campaignUpdateTemplate,
+} from './email-templates';
 
 export interface SuspensionEmailPayload {
   toEmail: string;
@@ -7,25 +17,159 @@ export interface SuspensionEmailPayload {
   reason: string;
 }
 
+export interface DonationReceivedPayload {
+  toEmail: string;
+  userId: string;
+  donorName: string;
+  amount: string;
+  assetCode: string;
+  campaignTitle: string;
+  campaignUrl: string;
+}
+
+export interface MilestoneUnlockedPayload {
+  toEmail: string;
+  userId: string;
+  campaignTitle: string;
+  milestoneTitle: string;
+  campaignUrl: string;
+}
+
+export interface CampaignUpdatePayload {
+  toEmail: string;
+  userId: string;
+  campaignTitle: string;
+  updateTitle: string;
+  updateContent: string;
+  campaignUrl: string;
+}
+
 @Injectable()
 export class NotificationsService {
   private readonly logger = new Logger(NotificationsService.name);
 
+  constructor(
+    private readonly prisma: PrismaService,
+    @InjectQueue(QUEUE_EMAIL) private readonly emailQueue: Queue,
+  ) {}
+
   /**
-   * Sends a suspension notice to the campaign creator.
-   * Replace the logger stub with a real mailer (e.g. nodemailer / @nestjs-modules/mailer)
-   * when an SMTP transport is configured.
+   * Check whether a user has enabled email notifications for a given notification type.
+   * preferenceKey corresponds to keys in the preferences JSON: donationReceived, milestoneUnlocked, campaignUpdate, etc.
+   */
+  async shouldSendEmail(userId: string, preferenceKey: string): Promise<boolean> {
+    try {
+      const user = await this.prisma.user.findUnique({
+        where: { id: userId },
+        include: { notificationPreference: true },
+      });
+
+      if (!user) return false;
+
+      // If user has no email, we can't send email
+      if (!user.email) return false;
+
+      const prefs = user.notificationPreference?.preferences as Record<
+        string,
+        { email?: boolean; inApp?: boolean }
+      > | null;
+
+      // If no preferences set, default to true (opt-in by default)
+      if (!prefs || !prefs[preferenceKey]) return true;
+
+      return prefs[preferenceKey]?.email !== false;
+    } catch (error) {
+      this.logger.error(
+        `Error checking notification preference ${preferenceKey} for user ${userId}: ${(error as Error).message}`,
+      );
+      return true; // Fail open — send the notification on error
+    }
+  }
+
+  /**
+   * Queue a donation received email via Bull.
+   */
+  async sendDonationReceivedEmail(payload: DonationReceivedPayload): Promise<void> {
+    const template = donationReceivedTemplate;
+    const html = template.html({
+      donorName: payload.donorName,
+      amount: payload.amount,
+      assetCode: payload.assetCode,
+      campaignTitle: payload.campaignTitle,
+      campaignUrl: payload.campaignUrl,
+    });
+
+    const jobData: EmailJobData = {
+      to: payload.toEmail,
+      subject: template.subject,
+      html,
+      preferenceKey: 'donationReceived',
+      userId: payload.userId,
+    };
+
+    await this.emailQueue.add('send-email', jobData);
+    this.logger.log(`Queued donation received email to ${payload.toEmail}`);
+  }
+
+  /**
+   * Queue a milestone unlocked email via Bull.
+   */
+  async sendMilestoneUnlockedEmail(payload: MilestoneUnlockedPayload): Promise<void> {
+    const template = milestoneUnlockedTemplate;
+    const html = template.html({
+      campaignTitle: payload.campaignTitle,
+      milestoneTitle: payload.milestoneTitle,
+      campaignUrl: payload.campaignUrl,
+    });
+
+    const jobData: EmailJobData = {
+      to: payload.toEmail,
+      subject: template.subject,
+      html,
+      preferenceKey: 'milestoneUnlocked',
+      userId: payload.userId,
+    };
+
+    await this.emailQueue.add('send-email', jobData);
+    this.logger.log(`Queued milestone unlocked email to ${payload.toEmail}`);
+  }
+
+  /**
+   * Queue a campaign update email via Bull.
+   */
+  async sendCampaignUpdateEmail(payload: CampaignUpdatePayload): Promise<void> {
+    const template = campaignUpdateTemplate;
+    const html = template.html({
+      campaignTitle: payload.campaignTitle,
+      updateTitle: payload.updateTitle,
+      updateContent: payload.updateContent,
+      campaignUrl: payload.campaignUrl,
+    });
+
+    const jobData: EmailJobData = {
+      to: payload.toEmail,
+      subject: template.subject,
+      html,
+      preferenceKey: 'campaignUpdate',
+      userId: payload.userId,
+    };
+
+    await this.emailQueue.add('send-email', jobData);
+    this.logger.log(`Queued campaign update email to ${payload.toEmail}`);
+  }
+
+  /**
+   * Sends a suspension notice to the campaign creator (synchronous, not queued).
    */
   async sendCampaignSuspensionEmail(payload: SuspensionEmailPayload): Promise<void> {
     this.logger.log(
       `[EMAIL] To: ${payload.toEmail} | Subject: Your campaign "${payload.campaignTitle}" has been suspended | Reason: ${payload.reason}`,
     );
     // TODO: replace with real mailer call, e.g.:
-    // await this.mailerService.sendMail({
+    // await this.emailService.send({
     //   to: payload.toEmail,
     //   subject: `Your campaign "${payload.campaignTitle}" has been suspended`,
-    //   template: 'campaign-suspension',
-    //   context: { campaignTitle: payload.campaignTitle, reason: payload.reason },
+    //   html: `...`,
     // });
   }
 }

--- a/src/stellar/stellar-transactions.service.ts
+++ b/src/stellar/stellar-transactions.service.ts
@@ -180,6 +180,49 @@ export class StellarTransactionsService {
     if (!opAsset) return false;
     return assetsEqual(asset, opAsset);
   }
+
+  /**
+   * Fetch on-chain asset balances for a Stellar account (contract or wallet).
+   * Queries Horizon for the account's native and issued asset balances.
+   */
+  async getContractBalances(
+    contractId: string,
+  ): Promise<{ assetCode: string; assetIssuer?: string; balance: string; isNative: boolean }[]> {
+    const res = await fetch(
+      `${this.horizonUrl}/accounts/${encodeURIComponent(contractId)}`,
+      { headers: { accept: 'application/json' } },
+    );
+
+    if (res.status === 404) {
+      return []; // account not yet funded — zero balance
+    }
+
+    if (!res.ok) {
+      throw new ServiceUnavailableException(
+        `Horizon error fetching account ${contractId} (${res.status})`,
+      );
+    }
+
+    const account = (await res.json()) as any;
+    const balances = account?.balances ?? [];
+
+    return balances.map((b: any) => {
+      const assetType = String(b.asset_type ?? '');
+      if (assetType === 'native') {
+        return {
+          assetCode: 'XLM',
+          balance: String(b.balance ?? '0'),
+          isNative: true,
+        };
+      }
+      return {
+        assetCode: String(b.asset_code ?? ''),
+        assetIssuer: String(b.asset_issuer ?? ''),
+        balance: String(b.balance ?? '0'),
+        isNative: false,
+      };
+    });
+  }
 }
 
 async function withRetries<T>(

--- a/src/users/dto/notification-preferences.dto.ts
+++ b/src/users/dto/notification-preferences.dto.ts
@@ -1,0 +1,45 @@
+import { IsOptional, IsBoolean, IsString } from 'class-validator';
+
+/**
+ * Toggle for a single notification type on a specific channel.
+ */
+export class NotificationChannelPreferenceDto {
+  @IsOptional()
+  @IsBoolean()
+  email?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  inApp?: boolean;
+}
+
+/**
+ * Full notification preferences structure.
+ */
+export class NotificationPreferencesDto {
+  donationReceived?: NotificationChannelPreferenceDto;
+  milestoneUnlocked?: NotificationChannelPreferenceDto;
+  campaignUpdate?: NotificationChannelPreferenceDto;
+  campaignCreated?: NotificationChannelPreferenceDto;
+  campaignCompleted?: NotificationChannelPreferenceDto;
+}
+
+/**
+ * DTO for PATCH /users/me/notification-preferences.
+ */
+export class UpdateNotificationPreferencesDto {
+  @IsOptional()
+  donationReceived?: NotificationChannelPreferenceDto;
+
+  @IsOptional()
+  milestoneUnlocked?: NotificationChannelPreferenceDto;
+
+  @IsOptional()
+  campaignUpdate?: NotificationChannelPreferenceDto;
+
+  @IsOptional()
+  campaignCreated?: NotificationChannelPreferenceDto;
+
+  @IsOptional()
+  campaignCompleted?: NotificationChannelPreferenceDto;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -14,6 +14,7 @@ import { UsersService } from './users.service';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UpdateKYCStatusDto } from './dto/update-kyc-status.dto';
 import { UserProfileDto, PublicUserProfileDto } from './dto/user-profile.dto';
+import { NotificationPreferencesDto, UpdateNotificationPreferencesDto } from './dto/notification-preferences.dto';
 import { GetUserDonationsQueryDto, GetUserDonationsResponseDto, ExportDonationHistoryQueryDto } from './dto/get-user-donations.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { AdminGuard } from './guards/admin.guard';
@@ -126,6 +127,34 @@ export class UsersController {
     }
 
     res.status(200).json({ status: result.status, rowCount: result.rowCount });
+  }
+
+  /**
+   * GET /users/me/notification-preferences
+   * Retrieve authenticated user's notification preferences
+   */
+  @UseGuards(JwtAuthGuard)
+  @Get('me/notification-preferences')
+  async getNotificationPreferences(
+    @Request() req: any,
+  ): Promise<NotificationPreferencesDto> {
+    return this.usersService.getNotificationPreferences(req.user.sub);
+  }
+
+  /**
+   * PATCH /users/me/notification-preferences
+   * Update authenticated user's notification preferences
+   */
+  @UseGuards(JwtAuthGuard)
+  @Patch('me/notification-preferences')
+  async updateNotificationPreferences(
+    @Request() req: any,
+    @Body() updateDto: UpdateNotificationPreferencesDto,
+  ): Promise<NotificationPreferencesDto> {
+    return this.usersService.updateNotificationPreferences(
+      req.user.sub,
+      updateDto,
+    );
   }
 
   /**

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -8,6 +8,10 @@ import type { Queue } from 'bull';
 import { PrismaService } from '../prisma/prisma.service';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UserProfileDto, PublicUserProfileDto } from './dto/user-profile.dto';
+import {
+  NotificationPreferencesDto,
+  UpdateNotificationPreferencesDto,
+} from './dto/notification-preferences.dto';
 import { QUEUE_EXPORT } from '../queue/queue.constants';
 import type { ExportDonationJobData } from './export.processor';
 
@@ -420,6 +424,83 @@ export class UsersService {
     }
 
     return { csv: rows.join('\n'), queued: false };
+  }
+
+  /**
+   * Get notification preferences for the current user.
+   * Creates default preferences if none exist.
+   */
+  async getNotificationPreferences(userId: string): Promise<NotificationPreferencesDto> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      include: { notificationPreference: true },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Return default preferences if none exist
+    if (!user.notificationPreference) {
+      return {
+        donationReceived: { email: true, inApp: true },
+        milestoneUnlocked: { email: true, inApp: true },
+        campaignUpdate: { email: true, inApp: true },
+        campaignCreated: { email: true, inApp: true },
+        campaignCompleted: { email: true, inApp: true },
+      };
+    }
+
+    return user.notificationPreference.preferences as unknown as NotificationPreferencesDto;
+  }
+
+  /**
+   * Update notification preferences for the current user.
+   * Creates a preference record if none exists, otherwise merges the update.
+   */
+  async updateNotificationPreferences(
+    userId: string,
+    updateDto: UpdateNotificationPreferencesDto,
+  ): Promise<NotificationPreferencesDto> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      include: { notificationPreference: true },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const existingPrefs = user.notificationPreference?.preferences as Record<
+      string,
+      { email?: boolean; inApp?: boolean }
+    > | null;
+
+    // Merge existing preferences with the update
+    const defaults = {
+      donationReceived: { email: true, inApp: true },
+      milestoneUnlocked: { email: true, inApp: true },
+      campaignUpdate: { email: true, inApp: true },
+      campaignCreated: { email: true, inApp: true },
+      campaignCompleted: { email: true, inApp: true },
+    };
+
+    const merged = { ...defaults, ...(existingPrefs as object) };
+
+    for (const [key, value] of Object.entries(updateDto)) {
+      if (value !== undefined) {
+        merged[key] = { ...merged[key], ...value };
+      }
+    }
+
+    // Upsert the preference record
+    const prefs = await this.prisma.notificationPreference.upsert({
+      where: { userId },
+      update: { preferences: merged },
+      create: { userId, preferences: merged },
+    });
+
+    return prefs.preferences as unknown as NotificationPreferencesDto;
   }
 
   /**


### PR DESCRIPTION
Closes #292 - Implement email notification service
Closes #293 - Implement notification preferences CRUD
closes #284
closes #291

## Changes

### Issue #293: Notification Preferences CRUD
- Added NotificationPreference model to Prisma schema with JSON preferences field
- Created DTOs for notification preferences (GET/PATCH request/response types)
- Added getNotificationPreferences() and updateNotificationPreferences() methods to UsersService
- Added GET /users/me/notification-preferences and PATCH /users/me/notification-preferences endpoints

### Issue #292: Email Notification Service
- Installed and configured nodemailer with SMTP transport (fallback to dev logging)
- Created EmailService with unsubscribe link support
- Created EmailProcessor for async email processing via Bull queue (checks user preferences before sending)
- Created HTML email templates for: donation received, milestone unlocked, campaign update
- Updated NotificationsService with shouldSendEmail() and methods to queue emails via Bull
- Added SMTP configuration to .env.example

### Bonus fixes
- Fixed duplicate isAnonymous field in Donation model
- Fixed Donation-PlatformTip bidirectional relation to pass Prisma v6 validation

## Notes
- Emails use Bull queue configured with exponential retry (3 attempts)
- Each email includes an unsubscribe link and respects user notification preferences
- In development without SMTP credentials, emails are logged to console