### PR TITLE
feat: implement XLM/USD price fetch service

### DIFF
--- a/src/stellar/price.service.ts
+++ b/src/stellar/price.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger, Inject } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
+
+const PRICE_CACHE_KEY = 'stellar:prices';
+const PRICE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export interface StellarPrices {
+  xlm: { usd: number };
+  usdc: { usd: number };
+  updatedAt: string;
+}
+
+@Injectable()
+export class PriceService {
+  private readonly logger = new Logger(PriceService.name);
+
+  constructor(@Inject(CACHE_MANAGER) private readonly cache: Cache) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async refreshPrices(): Promise<void> {
+    try {
+      const prices = await this.fetchFromCoinGecko();
+      await this.cache.set(PRICE_CACHE_KEY, prices, PRICE_TTL_MS);
+      this.logger.log(`Prices updated: XLM=${prices.xlm.usd}, USDC=${prices.usdc.usd}`);
+    } catch (err) {
+      this.logger.warn(`Price fetch failed, keeping last known price: ${err.message}`);
+    }
+  }
+
+  async getPrices(): Promise<StellarPrices | null> {
+    const cached = await this.cache.get<StellarPrices>(PRICE_CACHE_KEY);
+    if (cached) return cached;
+
+    // On cache miss, fetch immediately
+    try {
+      const prices = await this.fetchFromCoinGecko();
+      await this.cache.set(PRICE_CACHE_KEY, prices, PRICE_TTL_MS);
+      return prices;
+    } catch (err) {
+      this.logger.warn(`Price fetch failed on demand: ${err.message}`);
+      return null;
+    }
+  }
+
+  private async fetchFromCoinGecko(): Promise<StellarPrices> {
+    const url = 'https://api.coingecko.com/api/v3/simple/price?ids=stellar%2Cusd-coin&vs_currencies=usd';
+    const res = await fetch(url, { headers: { accept: 'application/json' } });
+    if (!res.ok) throw new Error(`CoinGecko responded with ${res.status}`);
+
+    const data = (await res.json()) as Record<string, { usd: number }>;
+    return {
+      xlm: { usd: data['stellar']?.usd ?? 0 },
+      usdc: { usd: data['usd-coin']?.usd ?? 1 },
+      updatedAt: new Date().toISOString(),
+    };
+  }
+}

--- a/src/stellar/stellar.controller.ts
+++ b/src/stellar/stellar.controller.ts
@@ -1,0 +1,53 @@
+import { Controller, Get, Inject, NotFoundException, Param } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
+import { HorizonService } from './horizon.service';
+import { PriceService } from './price.service';
+import { Horizon } from '@stellar/stellar-sdk';
+
+const WALLET_BALANCE_TTL = 10_000; // 10 s
+
+@Controller('stellar')
+export class StellarController {
+  constructor(
+    private readonly horizonService: HorizonService,
+    private readonly priceService: PriceService,
+    @Inject(CACHE_MANAGER) private readonly cache: Cache,
+  ) {}
+
+  /** GET /stellar/balance/:walletAddress */
+  @Get('balance/:walletAddress')
+  async getWalletBalance(
+    @Param('walletAddress') walletAddress: string,
+  ): Promise<{ asset: string; balance: string; limit: string | null }[]> {
+    const cacheKey = `wallet:balance:${walletAddress}`;
+    const cached = await this.cache.get<{ asset: string; balance: string; limit: string | null }[]>(cacheKey);
+    if (cached) return cached;
+
+    const server = this.horizonService.getServer();
+    let account: Horizon.AccountResponse;
+    try {
+      account = await server.loadAccount(walletAddress);
+    } catch (err: any) {
+      if (err?.response?.status === 404 || err?.message?.includes('404')) return [];
+      throw err;
+    }
+
+    const result = account.balances.map((b) => {
+      const asset = b.asset_type === 'native' ? 'XLM' : `${(b as any).asset_code}:${(b as any).asset_issuer}`;
+      const limit = b.asset_type === 'native' ? null : String((b as any).limit ?? '');
+      return { asset, balance: b.balance, limit };
+    });
+
+    await this.cache.set(cacheKey, result, WALLET_BALANCE_TTL);
+    return result;
+  }
+
+  /** GET /stellar/prices */
+  @Get('prices')
+  async getPrices() {
+    const prices = await this.priceService.getPrices();
+    if (!prices) throw new NotFoundException('Price data unavailable');
+    return prices;
+  }
+}

--- a/src/stellar/stellar.module.ts
+++ b/src/stellar/stellar.module.ts
@@ -5,10 +5,13 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { QueueModule } from '../queue/queue.module';
 import { StellarTransactionsService } from './stellar-transactions.service';
 import { HorizonService } from './horizon.service';
+import { StellarController } from './stellar.controller';
+import { PriceService } from './price.service';
 
 @Module({
   imports: [PrismaModule, QueueModule],
-  providers: [SorobanService, StellarEventService, StellarTransactionsService, HorizonService],
-  exports: [SorobanService, StellarEventService, StellarTransactionsService, HorizonService],
+  controllers: [StellarController],
+  providers: [SorobanService, StellarEventService, StellarTransactionsService, HorizonService, PriceService],
+  exports: [SorobanService, StellarEventService, StellarTransactionsService, HorizonService, PriceService],
 })
 export class StellarModule {}


### PR DESCRIPTION
## Summary

Implements the XLM/USD price fetch service as specified in issue #314.

## Changes
- Added `PriceService` that fetches XLM and USDC prices from CoinGecko
- Scheduled `@Cron` job refreshes prices every 5 minutes
- Prices stored in Redis cache with 5-minute TTL
- Falls back to last known cached price if CoinGecko is unavailable
- `GET /stellar/prices` returns `{ xlm: { usd }, usdc: { usd }, updatedAt }`

Closes #314