### PR TITLE
Configure database migration strategy for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,15 @@ $ npm run test:cov
 
 ## Deployment
 
-When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
+Production deploys must apply Prisma migrations before the API process starts.
+The production start command, `npm run start:prod`, runs `prisma migrate deploy`
+first via the `prestart:prod` lifecycle hook.
 
-If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
+Refer to [docs/deployment.md](./docs/deployment.md) for the deploy order, rollback
+plan, and migration-history notes.
 
-```bash
-$ npm install -g @nestjs/mau
-$ mau deploy
-```
-
-With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
+The same production database will track applied migration state in
+`_prisma_migrations`.
 
 ## Resources
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,40 @@
+# Deployment Runbook
+
+This service uses Prisma Migrate for production schema management.
+
+## Deploy Order
+
+1. Install dependencies.
+2. Build the API.
+3. Run `npm run start:prod`.
+4. The `prestart:prod` lifecycle hook runs `npm run prisma:deploy`.
+5. Prisma applies any pending migrations with `prisma migrate deploy`.
+6. Only after migrations succeed does `node dist/main` start the new API version.
+
+## Migration Tracking
+
+Prisma records migration history in the `_prisma_migrations` table.
+That table is the source of truth for which migrations have already been applied
+in a given environment.
+
+## Rollback Plan
+
+Prisma does not automatically roll back applied production migrations.
+Use this order of operations instead:
+
+1. Stop the newly deployed API version.
+2. Redeploy the previous known-good application release.
+3. If the schema change was backward-compatible, keep the database as-is and
+   rely on the older app version.
+4. If the migration was not backward-compatible, restore the last database
+   backup or snapshot taken before the deployment window.
+5. Once the database state matches the restored application version, reconcile
+   migration metadata if needed with Prisma commands such as
+   `prisma migrate resolve`.
+
+## Operational Rules
+
+- Use `prisma migrate dev` only in local development.
+- Never use `prisma migrate reset` in production.
+- Prefer additive, backward-compatible migrations so rollbacks only require an
+  application redeploy.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
+    "prestart:prod": "npm run prisma:deploy",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -20,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
+    "prisma:deploy": "prisma migrate deploy",
     "prisma:studio": "prisma studio",
     "postinstall": "prisma generate"
   },


### PR DESCRIPTION
Closes #335

**Changes:**
- Added `prestart:prod` lifecycle hook to run `prisma migrate deploy` before API starts (`package.json`)
- Added `prisma:deploy` script (`package.json`)
- Created `docs/deployment.md` with deploy order, rollback plan, and migration tracking documentation
- Updated `README.md` to point to the deployment docs

**Acceptance Criteria:**
- ✅ `prisma migrate deploy` runs as part of deploy pipeline (via `prestart:prod`)
- ✅ Migrations applied before new API version starts (`npm run start:prod` chain)
- ✅ Rollback plan documented in `docs/deployment.md`
- ✅ Migration history tracked in `_prisma_migrations` table (Prisma native)