### PR TITLE
feat(auth): implement user registration endpoint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+coverage
+*.config.js
+.eslintrc.js
+nest-cli.json

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,24 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    es2022: true,
+    jest: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    project: './tsconfig.json',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['plugin:@typescript-eslint/recommended', 'prettier'],
+  rules: {
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    'no-console': 'off',
+  },
+  ignorePatterns: ['dist', 'node_modules', 'coverage', '.eslintrc.js'],
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+coverage
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "semi": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@nestjs/mongoose": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/throttler": "^5.0.0",
+    "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "joi": "^17.11.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
 import * as Joi from 'joi';
+import { AuthModule } from './auth/auth.module';
 import { HealthModule } from './health/health.module';
 
 @Module({
@@ -51,6 +52,8 @@ import { HealthModule } from './health/health.module';
       }),
       inject: [ConfigService],
     }),
+
+    AuthModule,
 
     ThrottlerModule.forRoot([
       {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,41 @@
+import {
+  Body,
+  ConflictException,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Res,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { AuthService } from './auth.service';
+import { RegisterDto } from './dto/register.dto';
+import { sendError, sendSuccess } from '../utils/response.util';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('register')
+  @HttpCode(HttpStatus.CREATED)
+  async register(@Body() dto: RegisterDto, @Res() res: Response): Promise<Response> {
+    try {
+      const result = await this.authService.register({
+        fullName: dto.fullName,
+        email: dto.email,
+        password: dto.password,
+      });
+      return sendSuccess(
+        res,
+        result,
+        'User registered. Please verify your email to activate your account.',
+        HttpStatus.CREATED,
+      );
+    } catch (err) {
+      if (err instanceof ConflictException) {
+        return sendError(res, err.message, HttpStatus.CONFLICT);
+      }
+      throw err;
+    }
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { UsersModule } from '../users/users.module';
+import { MailModule } from '../mail/mail.module';
+
+@Module({
+  imports: [UsersModule, MailModule],
+  controllers: [AuthController],
+  providers: [AuthService],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { ConflictException } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
+import { MailService } from '../mail/mail.service';
+
+interface FauxUser {
+  _id: { toString: () => string };
+  fullName: string;
+  email: string;
+  isVerified: boolean;
+  emailVerificationToken: string | null;
+  emailVerificationExpires: Date | null;
+  save: jest.Mock;
+}
+
+describe('AuthService.register', () => {
+  let auth: AuthService;
+  let users: jest.Mocked<Pick<UsersService, 'findByEmail' | 'create'>>;
+  let mail: jest.Mocked<Pick<MailService, 'sendVerificationEmail'>>;
+
+  beforeEach(async () => {
+    users = {
+      findByEmail: jest.fn(),
+      create: jest.fn(),
+    };
+    mail = {
+      sendVerificationEmail: jest.fn(),
+    };
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: UsersService, useValue: users },
+        { provide: MailService, useValue: mail },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+      ],
+    }).compile();
+
+    auth = moduleRef.get(AuthService);
+  });
+
+  it('creates a user, generates a verification token, and emails it', async () => {
+    users.findByEmail.mockResolvedValue(null);
+    const fauxUser: FauxUser = {
+      _id: { toString: () => 'user-id-1' },
+      fullName: 'Ada Lovelace',
+      email: 'ada@example.com',
+      isVerified: false,
+      emailVerificationToken: null,
+      emailVerificationExpires: null,
+      save: jest.fn(async function (this: FauxUser) {
+        return this;
+      }),
+    };
+    users.create.mockResolvedValue(
+      fauxUser as unknown as Awaited<ReturnType<UsersService['create']>>,
+    );
+
+    const result = await auth.register({
+      fullName: 'Ada Lovelace',
+      email: 'ADA@example.com  ',
+      password: 'superSecret123',
+    });
+
+    expect(result.id).toBe('user-id-1');
+    expect(result.email).toBe('ada@example.com');
+    expect(result.fullName).toBe('Ada Lovelace');
+    expect(result.isVerified).toBe(false);
+
+    expect(users.findByEmail).toHaveBeenCalledWith('ada@example.com');
+    expect(users.create).toHaveBeenCalledWith({
+      fullName: 'Ada Lovelace',
+      email: 'ada@example.com',
+      password: 'superSecret123',
+    });
+
+    expect(fauxUser.emailVerificationToken).toMatch(/^[a-f0-9]{64}$/);
+    expect(fauxUser.emailVerificationExpires).toBeInstanceOf(Date);
+    expect(fauxUser.save).toHaveBeenCalledTimes(1);
+
+    expect(mail.sendVerificationEmail).toHaveBeenCalledTimes(1);
+    expect(mail.sendVerificationEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'ada@example.com',
+        name: 'Ada Lovelace',
+        token: fauxUser.emailVerificationToken,
+      }),
+    );
+  });
+
+  it('throws ConflictException when email is already registered', async () => {
+    users.findByEmail.mockResolvedValue({
+      _id: 'existing',
+    } as unknown as Awaited<ReturnType<UsersService['findByEmail']>>);
+
+    await expect(
+      auth.register({
+        fullName: 'Existing User',
+        email: 'existing@example.com',
+        password: 'whatever123',
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(users.create).not.toHaveBeenCalled();
+    expect(mail.sendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it('still returns success when email delivery fails (logged warning)', async () => {
+    users.findByEmail.mockResolvedValue(null);
+    const fauxUser: FauxUser = {
+      _id: { toString: () => 'user-id-2' },
+      fullName: 'Bob',
+      email: 'bob@example.com',
+      isVerified: false,
+      emailVerificationToken: null,
+      emailVerificationExpires: null,
+      save: jest.fn(async function (this: FauxUser) {
+        return this;
+      }),
+    };
+    users.create.mockResolvedValue(
+      fauxUser as unknown as Awaited<ReturnType<UsersService['create']>>,
+    );
+    mail.sendVerificationEmail.mockRejectedValue(new Error('SMTP down'));
+
+    const result = await auth.register({
+      fullName: 'Bob',
+      email: 'bob@example.com',
+      password: 'superSecret123',
+    });
+    expect(result.email).toBe('bob@example.com');
+  });
+});

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,71 @@
+import { ConflictException, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as crypto from 'crypto';
+import { UsersService } from '../users/users.service';
+import { MailService } from '../mail/mail.service';
+
+export interface RegisterInput {
+  fullName: string;
+  email: string;
+  password: string;
+}
+
+export interface RegisterResult {
+  id: string;
+  fullName: string;
+  email: string;
+  isVerified: boolean;
+}
+
+const VERIFICATION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+@Injectable()
+export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
+
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly mailService: MailService,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    private readonly configService: ConfigService,
+  ) {}
+
+  async register(input: RegisterInput): Promise<RegisterResult> {
+    const normalized = input.email.toLowerCase().trim();
+
+    const existing = await this.usersService.findByEmail(normalized);
+    if (existing) {
+      throw new ConflictException('Email already registered');
+    }
+
+    const user = await this.usersService.create({
+      fullName: input.fullName,
+      email: normalized,
+      password: input.password,
+    });
+
+    const token = crypto.randomBytes(32).toString('hex');
+    user.emailVerificationToken = token;
+    user.emailVerificationExpires = new Date(Date.now() + VERIFICATION_TTL_MS);
+    await user.save();
+
+    try {
+      await this.mailService.sendVerificationEmail({
+        to: user.email,
+        name: user.fullName,
+        token,
+      });
+    } catch (err) {
+      this.logger.warn(
+        `Failed to send verification email to ${user.email}: ${(err as Error).message}`,
+      );
+    }
+
+    return {
+      id: user._id?.toString() ?? '',
+      fullName: user.fullName,
+      email: user.email,
+      isVerified: user.isVerified,
+    };
+  }
+}

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -1,0 +1,17 @@
+import { IsEmail, IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class RegisterDto {
+  @IsString({ message: 'fullName must be a string' })
+  @IsNotEmpty({ message: 'fullName is required' })
+  @MaxLength(120, { message: 'fullName must be at most 120 characters' })
+  fullName!: string;
+
+  @IsEmail({}, { message: 'email must be a valid email address' })
+  @IsNotEmpty({ message: 'email is required' })
+  email!: string;
+
+  @IsString({ message: 'password must be a string' })
+  @MinLength(8, { message: 'password must be at least 8 characters' })
+  @MaxLength(128, { message: 'password must be at most 128 characters' })
+  password!: string;
+}

--- a/src/mail/mail.module.ts
+++ b/src/mail/mail.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { MailService } from './mail.service';
+
+@Module({
+  providers: [MailService],
+  exports: [MailService],
+})
+export class MailModule {}

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * Stub MailService used while the nodemailer-backed implementation (#363)
+ * is being built. Records every email in `sent` so tests and dev can read
+ * what would have been sent, then logs it.
+ */
+@Injectable()
+export class MailService {
+  private readonly logger = new Logger(MailService.name);
+
+  public readonly sent: Array<{
+    to: string;
+    subject: string;
+    html: string;
+  }> = [];
+
+  async sendEmail(args: { to: string; subject: string; html: string }): Promise<void> {
+    this.sent.push(args);
+    this.logger.log(`(stub) email queued to=${args.to} subject="${args.subject}"`);
+  }
+
+  async sendVerificationEmail(args: { to: string; name: string; token: string }): Promise<void> {
+    const link = `${process.env.APP_BASE_URL ?? 'http://localhost:3000'}/api/auth/verify-email/${args.token}`;
+    const html = `
+      <p>Hi ${args.name},</p>
+      <p>Welcome to StellarAid. Please verify your email by clicking the link below:</p>
+      <p><a href="${link}">${link}</a></p>
+      <p>This link expires in 24 hours.</p>
+    `;
+    return this.sendEmail({ to: args.to, subject: 'Verify your StellarAid email', html });
+  }
+}

--- a/src/users/schemas/user.schema.spec.ts
+++ b/src/users/schemas/user.schema.spec.ts
@@ -1,0 +1,91 @@
+import {
+  hashUserPassword,
+  User,
+  UserSchema,
+  UserRole,
+  KycStatus,
+  SALT_ROUNDS,
+} from './user.schema';
+
+describe('UserSchema', () => {
+  describe('hashUserPassword()', () => {
+    it('produces a bcrypt-hashed representation, not the plaintext', async () => {
+      const hash = await hashUserPassword('superSecret123');
+      expect(hash).not.toBe('superSecret123');
+      expect(hash.length).toBeGreaterThan(20);
+      expect(hash.startsWith('$2')).toBe(true); // bcryptjs prefix
+    });
+
+    it('produces a different hash for the same input (salt is random)', async () => {
+      const a = await hashUserPassword('superSecret123');
+      const b = await hashUserPassword('superSecret123');
+      expect(a).not.toBe(b);
+    });
+
+    it('uses a reduced salt rounds in test mode', () => {
+      expect(process.env.NODE_ENV === 'test' ? SALT_ROUNDS : SALT_ROUNDS).toBeGreaterThanOrEqual(4);
+    });
+  });
+
+  describe('User.comparePassword() (instance method)', () => {
+    it('returns true for a correct plaintext, false for a wrong one', async () => {
+      const stored = { password: await hashUserPassword('compIlerRocks') } as { password: string };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const anyUser: any = stored;
+      anyUser.comparePassword = UserSchema.methods.comparePassword;
+      await expect(anyUser.comparePassword('compIlerRocks')).resolves.toBe(true);
+      await expect(anyUser.comparePassword('wrongPassword')).resolves.toBe(false);
+    });
+  });
+
+  describe('toJSON transform', () => {
+    it('strips sensitive fields and exposes a string id', () => {
+      // Build a minimal faux mongoose doc and run the transform manually.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const anySchema: any = UserSchema;
+      const transform = anySchema.options?.toJSON?.transform;
+      expect(typeof transform).toBe('function');
+
+      const ret = {
+        _id: { toString: () => 'fake-id-123' },
+        __v: 0,
+        password: 'hidden',
+        refreshTokenHash: 'hidden',
+        passwordResetToken: 'hidden',
+        emailVerificationToken: 'hidden',
+        fullName: 'JSON Test',
+        email: 'json@example.com',
+      };
+      const out = transform(null, ret);
+      expect(out.id).toBe('fake-id-123');
+      expect(out.email).toBe('json@example.com');
+      expect(out).not.toHaveProperty('password');
+      expect(out).not.toHaveProperty('refreshTokenHash');
+      expect(out).not.toHaveProperty('passwordResetToken');
+      expect(out).not.toHaveProperty('emailVerificationToken');
+      expect(out).not.toHaveProperty('_id');
+      expect(out).not.toHaveProperty('__v');
+    });
+  });
+
+  describe('enum metadata', () => {
+    it('exposes UserRole.USER and UserRole.ADMIN with the spec values', () => {
+      expect(UserRole.USER).toBe('user');
+      expect(UserRole.ADMIN).toBe('admin');
+    });
+
+    it('exposes KycStatus values matching the spec', () => {
+      expect(KycStatus.PENDING).toBe('pending');
+      expect(KycStatus.APPROVED).toBe('approved');
+      expect(KycStatus.REJECTED).toBe('rejected');
+    });
+  });
+
+  it('User class is exported with a Mongoose Schema instance', () => {
+    expect(User.name).toBe('User');
+    expect(UserSchema).toBeDefined();
+    // Mongoose Schema exposes stable public APIs: .path, .indexes, .virtual.
+    expect(typeof UserSchema.path).toBe('function');
+    expect(Array.isArray(UserSchema.indexes())).toBe(true);
+  });
+});

--- a/src/users/schemas/user.schema.ts
+++ b/src/users/schemas/user.schema.ts
@@ -1,0 +1,109 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+import * as bcrypt from 'bcryptjs';
+
+export type UserDocument = User & Document;
+
+export enum UserRole {
+  USER = 'user',
+  ADMIN = 'admin',
+}
+
+export enum KycStatus {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+}
+
+/**
+ * Comprehensive User schema. Brings every field the auth/email/password
+ * workflow needs into one Mongoose model so downstream PRs can build on
+ * a stable schema instead of each adding fields in isolation.
+ */
+@Schema({
+  collection: 'users',
+  timestamps: true,
+  toJSON: {
+    virtuals: true,
+    transform: (_doc, ret: Record<string, unknown>) => {
+      const idSource = ret._id as { toString(): string } | undefined;
+      ret.id = idSource?.toString();
+      delete ret._id;
+      delete ret.__v;
+      delete ret.password;
+      delete ret.refreshTokenHash;
+      delete ret.passwordResetToken;
+      delete ret.emailVerificationToken;
+      return ret;
+    },
+  },
+})
+export class User {
+  @Prop({ type: String, required: true, trim: true })
+  fullName!: string;
+
+  @Prop({ type: String, required: true, unique: true, lowercase: true, trim: true, index: true })
+  email!: string;
+
+  @Prop({ type: String, required: true, minlength: 8 })
+  password!: string;
+
+  @Prop({ type: String, enum: Object.values(UserRole), default: UserRole.USER })
+  role!: UserRole;
+
+  @Prop({ type: Boolean, default: false })
+  isVerified!: boolean;
+
+  @Prop({ type: String, enum: Object.values(KycStatus), default: KycStatus.PENDING })
+  kycStatus!: KycStatus;
+
+  @Prop({ type: String, default: null })
+  walletAddress!: string | null;
+
+  // --- email verification tokens (used by issue #362) ---
+  @Prop({ type: String, default: null })
+  emailVerificationToken!: string | null;
+
+  @Prop({ type: Date, default: null })
+  emailVerificationExpires!: Date | null;
+
+  // --- password reset tokens (used by issues #368/#369) ---
+  @Prop({ type: String, default: null })
+  passwordResetToken!: string | null;
+
+  @Prop({ type: Date, default: null })
+  passwordResetExpires!: Date | null;
+
+  // --- refresh token (used by issues #364/#366/#367) ---
+  @Prop({ type: String, default: null })
+  refreshTokenHash!: string | null;
+
+  @Prop({ type: Date, default: null })
+  refreshTokenExpires!: Date | null;
+}
+
+export const UserSchema = SchemaFactory.createForClass(User);
+
+// Password hashing helper — exported so it can be unit-tested without spinning up Mongo.
+export const SALT_ROUNDS = process.env.NODE_ENV === 'test' ? 4 : 12;
+export function hashUserPassword(plain: string): Promise<string> {
+  return bcrypt.hash(plain, SALT_ROUNDS);
+}
+
+// Pre-save hook — hash the password whenever it is set or modified.
+UserSchema.pre<UserDocument>('save', async function (next) {
+  if (!this.isModified('password')) {
+    return next();
+  }
+  try {
+    this.password = await hashUserPassword(this.password);
+    return next();
+  } catch (err) {
+    return next(err as Error);
+  }
+});
+
+// Instance method — compare a candidate plaintext password against the stored hash.
+UserSchema.methods.comparePassword = function (candidate: string): Promise<boolean> {
+  return bcrypt.compare(candidate, this.password);
+};

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { User, UserSchema } from './schemas/user.schema';
+import { UsersService } from './users.service';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: User.name, schema: UserSchema }])],
+  providers: [UsersService],
+  exports: [UsersService, MongooseModule],
+})
+export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { User, UserDocument } from './schemas/user.schema';
+
+export interface CreateUserInput {
+  fullName: string;
+  email: string;
+  password: string;
+  role?: string;
+  walletAddress?: string | null;
+}
+
+/**
+ * Thin CRUD layer over the User Mongoose model. Auth and account
+ * services in downstream PRs read/write the user through this service
+ * so the User module owns all query semantics.
+ */
+@Injectable()
+export class UsersService {
+  constructor(@InjectModel(User.name) private readonly userModel: Model<UserDocument>) {}
+
+  async findById(id: string): Promise<UserDocument | null> {
+    return this.userModel.findById(id).exec();
+  }
+
+  async findByEmail(email: string): Promise<UserDocument | null> {
+    return this.userModel.findOne({ email: email.toLowerCase().trim() }).exec();
+  }
+
+  async findByVerificationToken(token: string): Promise<UserDocument | null> {
+    return this.userModel.findOne({ emailVerificationToken: token }).exec();
+  }
+
+  async findByPasswordResetToken(token: string): Promise<UserDocument | null> {
+    return this.userModel.findOne({ passwordResetToken: token }).exec();
+  }
+
+  async create(input: CreateUserInput): Promise<UserDocument> {
+    const created = await this.userModel.create({
+      ...input,
+      email: input.email.toLowerCase().trim(),
+    });
+    return created;
+  }
+
+  async update(id: string, updates: Partial<User>): Promise<UserDocument | null> {
+    return this.userModel.findByIdAndUpdate(id, updates, { new: true }).exec();
+  }
+
+  async updateByEmail(email: string, updates: Partial<User>): Promise<UserDocument | null> {
+    return this.userModel
+      .findOneAndUpdate({ email: email.toLowerCase().trim() }, updates, { new: true })
+      .exec();
+  }
+}

--- a/src/utils/response.util.ts
+++ b/src/utils/response.util.ts
@@ -1,0 +1,55 @@
+import { Response } from 'express';
+
+/**
+ * Standard API response envelope used across all controllers.
+ * Shape matches the convention already emitted by `AllExceptionsFilter`.
+ */
+export interface ApiResponse<T = unknown> {
+  success: boolean;
+  statusCode: number;
+  message: string;
+  data?: T;
+  errors?: string[];
+  timestamp?: string;
+}
+
+/**
+ * Send a successful response with the project's standard envelope.
+ *
+ * @example
+ *   return sendSuccess(res, user, 'User created', 201);
+ */
+export function sendSuccess<T>(res: Response, data: T, message = 'OK', statusCode = 200): Response {
+  const payload: ApiResponse<T> = {
+    success: true,
+    statusCode,
+    message,
+    data,
+    timestamp: new Date().toISOString(),
+  };
+  return res.status(statusCode).json(payload);
+}
+
+/**
+ * Send an error response with the project's standard envelope.
+ *
+ * @example
+ *   return sendError(res, 'Email already in use', 409);
+ */
+export function sendError(
+  res: Response,
+  message: string,
+  statusCode = 500,
+  errors?: string[],
+): Response {
+  const payload: ApiResponse = {
+    success: false,
+    statusCode,
+    message,
+    timestamp: new Date().toISOString(),
+  };
+  if (errors && errors.length > 0) {
+    payload.errors = errors;
+  }
+  return res.status(statusCode).json(payload);
+}


### PR DESCRIPTION
Closes #361

## Summary
- `src/auth/dto/register.dto.ts` — RegisterDto with `class-validator`: `fullName` (string, required, ≤120 chars), `email` (valid email, required), `password` (string, min 8, max 128).
- `src/auth/auth.service.ts` — `register(input)` looks up the email (lowercased/trimmed) → `ConflictException` if duplicate → `usersService.create({...})` (pre-save hook hashes the password via bcryptjs) → generate a 32-byte hex `emailVerificationToken` with a 24h `emailVerificationExpires` → save the user → queue a verification email. Email-send failures are logged but do not abort the registration.
- `src/auth/auth.controller.ts` — `@Post('register')` @HttpCode(201), returning the project's standard envelope (`{ success, statusCode, message, data }`) via `src/utils/response.util.ts`. ConflictException → 409 via `sendError`.
- `src/auth/auth.module.ts` — wires `UsersModule` + `MailModule` and exports `AuthService` so future auth PRs can reuse it.
- `src/auth/auth.service.spec.ts` — 3 jest cases (happy path token + email queued, duplicate email rejection, graceful email-delivery degradation). 3/3 passing.
- `src/mail/{mail.service.ts, mail.module.ts}` — stub `MailService` that records every "sent" email in-memory for tests/dev and logs it; replaced by the real nodemailer-backed impl in PR #363.
- `src/app.module.ts` — imports `AuthModule` so `POST /api/auth/register` is reachable.

## Adaptation
Issue spec referenced an Express-style endpoint in plain JS. Implemented as a NestJS controller + service + module that integrate with the project's existing `@nestjs/mongoose` `User` model (PR #360 prerequisite), the response-helper util (PR #359), and the standard envelope convention emitted by `AllExceptionsFilter`.

## Validation
- `npm install` clean
- `npm run build` — clean
- `npx jest src/auth/auth.service.spec.ts` — 3/3 passing
- `npx eslint` — 0 errors
- `npx prettier --check` — clean