### PR TITLE
feat(admin): update user role, status, KYC review and list endpoints

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,11 +1,15 @@
 import {
+  Body,
   Controller,
   Delete,
   ForbiddenException,
+  Get,
   HttpCode,
   HttpStatus,
   NotFoundException,
   Param,
+  Patch,
+  Query,
   Res,
   UseGuards,
 } from '@nestjs/common';
@@ -17,14 +21,19 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { UserRole } from '../users/schemas/user.schema';
 import { sendError, sendSuccess } from '../utils/response.util';
+import { UpdateRoleDto } from './dto/update-role.dto';
+import { UpdateStatusDto } from './dto/update-status.dto';
+import { ReviewKycDto } from './dto/review-kyc.dto';
+import { KycReviewStatus } from '../kyc/schemas/kyc.schema';
 
-@Controller('api/admin/users')
+@Controller('api/admin')
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Roles(UserRole.ADMIN)
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}
 
-  @Delete(':id')
+  // Existing: DELETE /api/admin/users/:id
+  @Delete('users/:id')
   @HttpCode(HttpStatus.OK)
   async deleteUser(
     @Param('id') id: string,
@@ -34,18 +43,83 @@ export class AdminController {
     if (currentUser.sub === id) {
       return sendError(res, 'Admins cannot delete their own account', HttpStatus.FORBIDDEN);
     }
-
     try {
       await this.adminService.softDelete(id);
       return sendSuccess(res, null, 'User account deleted successfully', HttpStatus.OK);
     } catch (err) {
-      if (err instanceof NotFoundException) {
-        return sendError(res, err.message, HttpStatus.NOT_FOUND);
-      }
-      if (err instanceof ForbiddenException) {
-        return sendError(res, err.message, HttpStatus.FORBIDDEN);
-      }
+      if (err instanceof NotFoundException) return sendError(res, err.message, HttpStatus.NOT_FOUND);
+      if (err instanceof ForbiddenException) return sendError(res, err.message, HttpStatus.FORBIDDEN);
       throw err;
     }
+  }
+
+  // #386: PATCH /api/admin/users/:id/role
+  @Patch('users/:id/role')
+  @HttpCode(HttpStatus.OK)
+  async updateRole(
+    @Param('id') id: string,
+    @Body() dto: UpdateRoleDto,
+    @CurrentUser() currentUser: JwtPayload,
+    @Res() res: Response,
+  ): Promise<Response> {
+    try {
+      const user = await this.adminService.updateRole(id, dto.role, currentUser.sub);
+      return sendSuccess(res, user, 'User role updated successfully');
+    } catch (err) {
+      if (err instanceof NotFoundException) return sendError(res, err.message, HttpStatus.NOT_FOUND);
+      if (err instanceof ForbiddenException) return sendError(res, err.message, HttpStatus.FORBIDDEN);
+      throw err;
+    }
+  }
+
+  // #391: PATCH /api/admin/users/:id/status
+  @Patch('users/:id/status')
+  @HttpCode(HttpStatus.OK)
+  async updateStatus(
+    @Param('id') id: string,
+    @Body() dto: UpdateStatusDto,
+    @CurrentUser() currentUser: JwtPayload,
+    @Res() res: Response,
+  ): Promise<Response> {
+    try {
+      const user = await this.adminService.updateStatus(id, dto.status, currentUser.sub);
+      return sendSuccess(res, user, 'User status updated successfully');
+    } catch (err) {
+      if (err instanceof NotFoundException) return sendError(res, err.message, HttpStatus.NOT_FOUND);
+      if (err instanceof ForbiddenException) return sendError(res, err.message, HttpStatus.FORBIDDEN);
+      throw err;
+    }
+  }
+
+  // #392: PATCH /api/admin/kyc/:id
+  @Patch('kyc/:id')
+  @HttpCode(HttpStatus.OK)
+  async reviewKyc(
+    @Param('id') id: string,
+    @Body() dto: ReviewKycDto,
+    @Res() res: Response,
+  ): Promise<Response> {
+    try {
+      const kyc = await this.adminService.reviewKyc(id, dto.status, dto.reviewNote);
+      return sendSuccess(res, kyc, 'KYC submission reviewed successfully');
+    } catch (err) {
+      if (err instanceof NotFoundException) return sendError(res, err.message, HttpStatus.NOT_FOUND);
+      throw err;
+    }
+  }
+
+  // #393: GET /api/admin/kyc
+  @Get('kyc')
+  @HttpCode(HttpStatus.OK)
+  async listKyc(
+    @Query('status') status: KycReviewStatus | undefined,
+    @Res() res: Response,
+  ): Promise<Response> {
+    const validStatuses = Object.values(KycReviewStatus) as string[];
+    if (status && !validStatuses.includes(status)) {
+      return sendError(res, `Invalid status. Must be one of: ${validStatuses.join(', ')}`, HttpStatus.BAD_REQUEST);
+    }
+    const submissions = await this.adminService.listKyc(status);
+    return sendSuccess(res, submissions, 'KYC submissions retrieved successfully');
   }
 }

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,13 +1,18 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule, JwtModuleOptions } from '@nestjs/jwt';
+import { MongooseModule } from '@nestjs/mongoose';
 import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
 import { UsersModule } from '../users/users.module';
+import { Kyc, KycSchema } from '../kyc/schemas/kyc.schema';
+import { MailModule } from '../mail/mail.module';
 
 @Module({
   imports: [
     UsersModule,
+    MailModule,
+    MongooseModule.forFeature([{ name: Kyc.name, schema: KycSchema }]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       useFactory: (configService: ConfigService): JwtModuleOptions => ({

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,17 +1,76 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
-import { User, UserDocument } from '../users/schemas/user.schema';
+import { User, UserDocument, UserRole, UserStatus } from '../users/schemas/user.schema';
+import { Kyc, KycDocument, KycReviewStatus } from '../kyc/schemas/kyc.schema';
+import { MailService } from '../mail/mail.service';
+import { KycStatus } from '../users/schemas/user.schema';
 
 @Injectable()
 export class AdminService {
-  constructor(@InjectModel(User.name) private readonly userModel: Model<UserDocument>) {}
+  constructor(
+    @InjectModel(User.name) private readonly userModel: Model<UserDocument>,
+    @InjectModel(Kyc.name) private readonly kycModel: Model<KycDocument>,
+    private readonly mailService: MailService,
+  ) {}
 
   async softDelete(userId: string): Promise<void> {
     const user = await this.userModel.findById(userId).exec();
     if (!user) throw new NotFoundException('User not found');
-
     user.deletedAt = new Date();
     await user.save();
+  }
+
+  // #386
+  async updateRole(userId: string, role: UserRole, requesterId: string): Promise<UserDocument> {
+    if (userId === requesterId) throw new ForbiddenException('Admins cannot change their own role');
+    const user = await this.userModel.findByIdAndUpdate(userId, { role }, { new: true }).exec();
+    if (!user) throw new NotFoundException('User not found');
+    return user;
+  }
+
+  // #391
+  async updateStatus(userId: string, status: UserStatus, requesterId: string): Promise<UserDocument> {
+    if (userId === requesterId) throw new ForbiddenException('Admins cannot change their own status');
+    const user = await this.userModel.findByIdAndUpdate(userId, { status }, { new: true }).exec();
+    if (!user) throw new NotFoundException('User not found');
+    return user;
+  }
+
+  // #392
+  async reviewKyc(kycId: string, status: KycReviewStatus.APPROVED | KycReviewStatus.REJECTED, reviewNote?: string): Promise<KycDocument> {
+    const kyc = await this.kycModel.findByIdAndUpdate(
+      kycId,
+      { status, reviewNote: reviewNote ?? null, reviewedAt: new Date() },
+      { new: true },
+    ).exec();
+    if (!kyc) throw new NotFoundException('KYC submission not found');
+
+    const kycStatus = status === KycReviewStatus.APPROVED ? KycStatus.APPROVED : KycStatus.REJECTED;
+    const user = await this.userModel.findByIdAndUpdate(kyc.userId, { kycStatus }, { new: true }).exec();
+
+    if (user) {
+      const decision = status === KycReviewStatus.APPROVED ? 'approved' : 'rejected';
+      await this.mailService.sendEmail({
+        to: user.email,
+        subject: `Your KYC submission has been ${decision}`,
+        html: `<p>Hi ${user.fullName},</p><p>Your KYC submission has been <strong>${decision}</strong>.${reviewNote ? ` Note: ${reviewNote}` : ''}</p>`,
+      });
+    }
+
+    return kyc;
+  }
+
+  // #393
+  async listKyc(status?: KycReviewStatus): Promise<Array<{ kyc: KycDocument; user: Partial<UserDocument> | null }>> {
+    const filter = status ? { status } : {};
+    const submissions = await this.kycModel.find(filter).sort({ submittedAt: -1 }).exec();
+
+    return Promise.all(
+      submissions.map(async (kyc) => {
+        const user = await this.userModel.findById(kyc.userId).select('fullName email kycStatus').exec();
+        return { kyc, user };
+      }),
+    );
   }
 }

--- a/src/admin/dto/review-kyc.dto.ts
+++ b/src/admin/dto/review-kyc.dto.ts
@@ -1,0 +1,11 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { KycReviewStatus } from '../../kyc/schemas/kyc.schema';
+
+export class ReviewKycDto {
+  @IsEnum([KycReviewStatus.APPROVED, KycReviewStatus.REJECTED])
+  status!: KycReviewStatus.APPROVED | KycReviewStatus.REJECTED;
+
+  @IsOptional()
+  @IsString()
+  reviewNote?: string;
+}

--- a/src/admin/dto/update-role.dto.ts
+++ b/src/admin/dto/update-role.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { UserRole } from '../../users/schemas/user.schema';
+
+export class UpdateRoleDto {
+  @IsEnum(UserRole)
+  role!: UserRole;
+}

--- a/src/admin/dto/update-status.dto.ts
+++ b/src/admin/dto/update-status.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { UserStatus } from '../../users/schemas/user.schema';
+
+export class UpdateStatusDto {
+  @IsEnum(UserStatus)
+  status!: UserStatus;
+}

--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -1,18 +1,3 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { AuthGuard } from '@nestjs/passport';
-import { ExecutionContext } from '@nestjs/common';
-
-@Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {
-  canActivate(context: ExecutionContext) {
-    return super.canActivate(context);
-  }
-
-  handleRequest(err: any, user: any, info: any) {
-    if (err || !user) {
-      throw err || new UnauthorizedException('Invalid or missing authentication token');
-    }
-    return user;
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -19,9 +19,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validate(payload: any) {
     const user = await this.usersService.findById(payload.sub);
-    if (!user) {
-      throw new UnauthorizedException('User not found');
-    }
+    if (!user) throw new UnauthorizedException('User not found');
+    if (user.status === 'suspended') throw new UnauthorizedException('Account suspended');
     return user;
   }
 }

--- a/src/users/schemas/user.schema.ts
+++ b/src/users/schemas/user.schema.ts
@@ -9,6 +9,11 @@ export enum UserRole {
   ADMIN = 'admin',
 }
 
+export enum UserStatus {
+  ACTIVE = 'active',
+  SUSPENDED = 'suspended',
+}
+
 export enum KycStatus {
   NOT_SUBMITTED = 'not_submitted',
   PENDING = 'pending',
@@ -51,6 +56,9 @@ export class User {
 
   @Prop({ type: String, enum: Object.values(UserRole), default: UserRole.USER })
   role!: UserRole;
+
+  @Prop({ type: String, enum: Object.values(UserStatus), default: UserStatus.ACTIVE })
+  status!: UserStatus;
 
   @Prop({ type: Boolean, default: false })
   isVerified!: boolean;


### PR DESCRIPTION
- #386: PATCH /api/admin/users/:id/role - update role, block self-demotion
- #391: Add UserStatus to schema + PATCH /api/admin/users/:id/status - suspend/activate, block suspended users in JwtStrategy
- #392: PATCH /api/admin/kyc/:id - approve/reject KYC, update user kycStatus, email notification
- #393: GET /api/admin/kyc - list all KYC submissions with user info, filterable by status

Closes #386
Closes #391
Closes #392
Closes #393